### PR TITLE
feat: add import/write capabilities and transaction management tools

### DIFF
--- a/pp_terminal/commands/import_data.py
+++ b/pp_terminal/commands/import_data.py
@@ -1,0 +1,248 @@
+"""
+    Copyright (C) 2025-26 Daniel Gehriger
+
+    This file is part of pp-terminal.
+
+    pp-terminal is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    pp-terminal is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with pp-terminal. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, cast
+
+import typer
+from rich.console import Console
+from typing_extensions import Annotated
+
+from pp_terminal.data.xml_writer import PpXmlWriter
+
+app = typer.Typer()
+console = Console()
+log = logging.getLogger(__name__)
+
+
+def _get_writer(ctx: typer.Context) -> PpXmlWriter:
+    source_file = cast(Path, ctx.obj.source_file)
+    return PpXmlWriter(source_file)
+
+
+@app.command(name="security")
+def import_security(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Argument(help="Security display name")],
+    currency: Annotated[str, typer.Argument(help="Trading currency (e.g. EUR, USD)")],
+    isin: Annotated[Optional[str], typer.Option(help="ISIN identifier")] = None,
+    wkn: Annotated[Optional[str], typer.Option(help="WKN identifier")] = None,
+    ticker: Annotated[Optional[str], typer.Option(help="Ticker symbol")] = None,
+    feed: Annotated[str, typer.Option(help="Price feed source")] = "MANUAL",
+) -> None:
+    """Add a new security definition."""
+    writer = _get_writer(ctx)
+    sec_uuid = writer.add_security(name, currency, isin=isin, wkn=wkn, ticker=ticker, feed=feed)
+    console.print(f"[green]Created security[/green] '{name}' (uuid={sec_uuid})")
+
+
+@app.command(name="buy")
+def import_buy(
+    ctx: typer.Context,
+    security: Annotated[str, typer.Argument(help="ISIN or security UUID")],
+    account_id: Annotated[str, typer.Argument(help="Cash account UUID")],
+    date: Annotated[str, typer.Argument(help="Transaction date (ISO format)")],
+    shares: Annotated[float, typer.Argument(help="Number of shares")],
+    amount: Annotated[float, typer.Argument(help="Total amount in currency units")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    fees: Annotated[float, typer.Option(help="Transaction fees")] = 0.0,
+    taxes: Annotated[float, typer.Option(help="Transaction taxes")] = 0.0,
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Record a BUY transaction."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_buy(
+        security, account_id, datetime.fromisoformat(date),
+        shares, amount, currency, fees=fees, taxes=taxes, note=note,
+    )
+    console.print(f"[green]Created BUY[/green] {shares} shares (uuid={txn_uuid})")
+
+
+@app.command(name="sell")
+def import_sell(
+    ctx: typer.Context,
+    security: Annotated[str, typer.Argument(help="ISIN or security UUID")],
+    account_id: Annotated[str, typer.Argument(help="Cash account UUID")],
+    date: Annotated[str, typer.Argument(help="Transaction date (ISO format)")],
+    shares: Annotated[float, typer.Argument(help="Number of shares")],
+    amount: Annotated[float, typer.Argument(help="Total proceeds in currency units")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    fees: Annotated[float, typer.Option(help="Transaction fees")] = 0.0,
+    taxes: Annotated[float, typer.Option(help="Transaction taxes")] = 0.0,
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Record a SELL transaction."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_sell(
+        security, account_id, datetime.fromisoformat(date),
+        shares, amount, currency, fees=fees, taxes=taxes, note=note,
+    )
+    console.print(f"[green]Created SELL[/green] {shares} shares (uuid={txn_uuid})")
+
+
+@app.command(name="dividend")
+def import_dividend(
+    ctx: typer.Context,
+    security: Annotated[str, typer.Argument(help="ISIN or security UUID")],
+    account_id: Annotated[str, typer.Argument(help="Cash account UUID")],
+    date: Annotated[str, typer.Argument(help="Payment date (ISO format)")],
+    amount: Annotated[float, typer.Argument(help="Net dividend amount")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    shares: Annotated[float, typer.Option(help="Shares at ex-dividend date")] = 0.0,
+    taxes: Annotated[float, typer.Option(help="Withholding taxes")] = 0.0,
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Record a DIVIDEND payment."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_dividend(
+        security, account_id, datetime.fromisoformat(date),
+        amount, currency, shares=shares, taxes=taxes, note=note,
+    )
+    console.print(f"[green]Created DIVIDENDS[/green] {amount} {currency} (uuid={txn_uuid})")
+
+
+@app.command(name="deposit")
+def import_deposit(
+    ctx: typer.Context,
+    account_id: Annotated[str, typer.Argument(help="Cash account UUID")],
+    date: Annotated[str, typer.Argument(help="Deposit date (ISO format)")],
+    amount: Annotated[float, typer.Argument(help="Deposit amount")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Record a cash DEPOSIT."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_deposit(
+        account_id, datetime.fromisoformat(date), amount, currency, note=note,
+    )
+    console.print(f"[green]Created DEPOSIT[/green] {amount} {currency} (uuid={txn_uuid})")
+
+
+@app.command(name="withdrawal")
+def import_withdrawal(
+    ctx: typer.Context,
+    account_id: Annotated[str, typer.Argument(help="Cash account UUID")],
+    date: Annotated[str, typer.Argument(help="Withdrawal date (ISO format)")],
+    amount: Annotated[float, typer.Argument(help="Withdrawal amount")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Record a cash WITHDRAWAL (removal)."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_withdrawal(
+        account_id, datetime.fromisoformat(date), amount, currency, note=note,
+    )
+    console.print(f"[green]Created REMOVAL[/green] {amount} {currency} (uuid={txn_uuid})")
+
+
+@app.command(name="stock-split")
+def import_stock_split(
+    ctx: typer.Context,
+    security: Annotated[str, typer.Argument(help="ISIN or security UUID")],
+    date: Annotated[str, typer.Argument(help="Split date (ISO format)")],
+    ratio: Annotated[str, typer.Argument(help="Split ratio (e.g. '4:1')")],
+) -> None:
+    """Record a STOCK_SPLIT event on a security."""
+    writer = _get_writer(ctx)
+    writer.add_stock_split(security, datetime.fromisoformat(date), ratio)
+    console.print(f"[green]Created STOCK_SPLIT[/green] {ratio} on {date}")
+
+
+@app.command(name="delivery-in")
+def import_delivery_inbound(
+    ctx: typer.Context,
+    security: Annotated[str, typer.Argument(help="ISIN or security UUID")],
+    portfolio_id: Annotated[str, typer.Argument(help="Portfolio (securities account) UUID")],
+    date: Annotated[str, typer.Argument(help="Delivery date (ISO format)")],
+    shares: Annotated[float, typer.Argument(help="Number of shares")],
+    amount: Annotated[float, typer.Argument(help="Market value at delivery")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    fees: Annotated[float, typer.Option(help="Fees")] = 0.0,
+    taxes: Annotated[float, typer.Option(help="Taxes")] = 0.0,
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Record a DELIVERY_INBOUND (shares in without cash)."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_delivery_inbound(
+        security, portfolio_id, datetime.fromisoformat(date),
+        shares, amount, currency, fees=fees, taxes=taxes, note=note,
+    )
+    console.print(f"[green]Created DELIVERY_INBOUND[/green] {shares} shares (uuid={txn_uuid})")
+
+
+@app.command(name="delivery-out")
+def import_delivery_outbound(
+    ctx: typer.Context,
+    security: Annotated[str, typer.Argument(help="ISIN or security UUID")],
+    portfolio_id: Annotated[str, typer.Argument(help="Portfolio (securities account) UUID")],
+    date: Annotated[str, typer.Argument(help="Delivery date (ISO format)")],
+    shares: Annotated[float, typer.Argument(help="Number of shares")],
+    amount: Annotated[float, typer.Argument(help="Market value at delivery")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    fees: Annotated[float, typer.Option(help="Fees")] = 0.0,
+    taxes: Annotated[float, typer.Option(help="Taxes")] = 0.0,
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Record a DELIVERY_OUTBOUND (shares out without cash)."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_delivery_outbound(
+        security, portfolio_id, datetime.fromisoformat(date),
+        shares, amount, currency, fees=fees, taxes=taxes, note=note,
+    )
+    console.print(f"[green]Created DELIVERY_OUTBOUND[/green] {shares} shares (uuid={txn_uuid})")
+
+
+@app.command(name="interest")
+def import_interest_cmd(
+    ctx: typer.Context,
+    account_id: Annotated[str, typer.Argument(help="Cash account UUID")],
+    date: Annotated[str, typer.Argument(help="Payment date (ISO format)")],
+    amount: Annotated[float, typer.Argument(help="Interest amount")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    taxes: Annotated[float, typer.Option(help="Withholding taxes")] = 0.0,
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Record an INTEREST payment."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_interest(
+        account_id, datetime.fromisoformat(date),
+        amount, currency, taxes=taxes, note=note,
+    )
+    console.print(f"[green]Created INTEREST[/green] {amount} {currency} (uuid={txn_uuid})")
+
+
+@app.command(name="transfer")
+def import_transfer(
+    ctx: typer.Context,
+    from_account_id: Annotated[str, typer.Argument(help="Source cash account UUID")],
+    to_account_id: Annotated[str, typer.Argument(help="Destination cash account UUID")],
+    date: Annotated[str, typer.Argument(help="Transfer date (ISO format)")],
+    amount: Annotated[float, typer.Argument(help="Transfer amount")],
+    currency: Annotated[str, typer.Argument(help="Currency (e.g. EUR)")],
+    note: Annotated[Optional[str], typer.Option(help="Transaction note")] = None,
+) -> None:
+    """Transfer cash between two deposit accounts."""
+    writer = _get_writer(ctx)
+    txn_uuid = writer.add_account_transfer(
+        from_account_id, to_account_id, datetime.fromisoformat(date),
+        amount, currency, note=note,
+    )
+    console.print(f"[green]Created ACCOUNT_TRANSFER[/green] {amount} {currency} (uuid={txn_uuid})")

--- a/pp_terminal/commands/import_data.py
+++ b/pp_terminal/commands/import_data.py
@@ -28,6 +28,9 @@ from typing_extensions import Annotated
 
 from pp_terminal.data.xml_writer import PpXmlWriter
 
+# CLI commands for transaction types unavoidably take many parameters.
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+
 app = typer.Typer()
 console = Console()
 log = logging.getLogger(__name__)

--- a/pp_terminal/data/xml_writer.py
+++ b/pp_terminal/data/xml_writer.py
@@ -22,6 +22,7 @@ import shutil
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import lxml.etree as ET  # pylint: disable=c-extension-no-member
 
@@ -50,8 +51,8 @@ class PpXmlWriter:
     def __init__(self, file_path: Path):
         self._file_path = file_path
         self._parser = ET.XMLParser(remove_blank_text=False, resolve_entities=False, no_network=True)
-        self._tree: ET.ElementTree | None = None
-        self._root: ET.Element | None = None
+        self._tree: ET.ElementTree = None  # noqa  # set by _load()
+        self._root: ET.Element = None  # noqa  # set by _load()
         self._id_counter: int | None = None
 
     def _load(self) -> None:
@@ -175,7 +176,7 @@ class PpXmlWriter:
         return None
 
     def _make_sub(self, parent: ET.Element, tag: str, text: str | None = None,
-                  attribs: dict | None = None, with_id: bool = False) -> ET.Element:
+                  attribs: dict[str, str] | None = None, with_id: bool = False) -> ET.Element:
         el = ET.SubElement(parent, tag)
         if with_id:
             el.set('id', self._alloc_id())
@@ -198,7 +199,7 @@ class PpXmlWriter:
 
     # ─── Public API ───
 
-    def delete_transaction(self, txn_uuid: str, backup: bool = True) -> dict:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    def delete_transaction(self, txn_uuid: str, backup: bool = True) -> dict[str, Any]:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """Delete a transaction by UUID. Handles cross-entry cleanup for transfers.
 
         Returns a dict with details of what was deleted.
@@ -217,7 +218,7 @@ class PpXmlWriter:
             raise InputError(f"Transaction with UUID '{txn_uuid}' not found")
 
         ttype = txn_el.findtext('type', '?')
-        result: dict = {'uuid': txn_uuid, 'type': ttype, 'deleted': []}
+        result: dict[str, Any] = {'uuid': txn_uuid, 'type': ttype, 'deleted': []}
 
         # Simple (non-transfer) account transaction or portfolio transaction
         if ttype not in ('TRANSFER_IN', 'TRANSFER_OUT'):

--- a/pp_terminal/data/xml_writer.py
+++ b/pp_terminal/data/xml_writer.py
@@ -27,6 +27,11 @@ import lxml.etree as ET  # pylint: disable=c-extension-no-member
 
 from pp_terminal.exceptions import InputError
 
+# Transaction functions unavoidably take many parameters (date, amount,
+# currency, fees, taxes, note, …).  Suppress the corresponding refactor
+# messages for the whole module rather than annotating every function.
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+
 log = logging.getLogger(__name__)
 
 # PP stores monetary amounts in 1/100 of the base unit (cents)
@@ -47,6 +52,7 @@ class PpXmlWriter:
         self._parser = ET.XMLParser(remove_blank_text=False, resolve_entities=False, no_network=True)
         self._tree: ET.ElementTree | None = None
         self._root: ET.Element | None = None
+        self._id_counter: int | None = None
 
     def _load(self) -> None:
         self._tree = ET.parse(str(self._file_path), self._parser)
@@ -79,7 +85,7 @@ class PpXmlWriter:
 
     def _alloc_id(self) -> str:
         """Allocate a new unique integer id, tracking allocations within a session."""
-        if not hasattr(self, '_id_counter'):
+        if self._id_counter is None:
             self._id_counter = self._next_id()
         id_str = str(self._id_counter)
         self._id_counter += 1
@@ -123,12 +129,13 @@ class PpXmlWriter:
     def _find_account_el(self, account_id: str, account_type: str = 'account') -> ET.Element:
         """Find an <account> or <portfolio> element by UUID.
 
-        Iterates the entire tree because PP XML may define elements inline
-        (e.g. a portfolio inside a crossEntry) with only a reference in the
-        top-level section.
+        Iterates the entire tree because PP XML (serialised by XStream) may
+        define the canonical element under any tag name — for instance the
+        first occurrence of an account might be ``<accountTo>`` inside a
+        crossEntry, with the ``<account>`` entries in ``<accounts>`` being
+        mere references.  Therefore we search **all** elements by UUID.
         """
-        tag_name = 'account' if account_type == 'account' else 'portfolio'
-        for el in self._root.iter(tag_name):
+        for el in self._root.iter():
             if el.get('reference') is not None:
                 continue
             uuid_el = el.find('uuid')
@@ -139,24 +146,25 @@ class PpXmlWriter:
     def _find_portfolio_for_account(self, account_id: str) -> ET.Element:
         """Find the portfolio that references the given cash account.
 
-        Iterates the entire tree because the portfolio definition may be
-        nested inside a crossEntry rather than directly under <portfolios>.
+        Searches all elements because XStream may define the canonical
+        portfolio under a tag other than ``<portfolio>``.
         """
         acc_el = self._find_account_el(account_id, 'account')
         acc_xml_id = acc_el.get('id')
 
-        for port in self._root.iter('portfolio'):
-            if port.get('reference') is not None:
+        for el in self._root.iter():
+            if el.get('reference') is not None:
                 continue
-            ref_acc = port.find('referenceAccount')
-            if ref_acc is not None:
-                if ref_acc.get('reference') is not None:
-                    if ref_acc.get('reference') == acc_xml_id:
-                        return port
-                else:
-                    ref_uuid = ref_acc.find('uuid')
-                    if ref_uuid is not None and ref_uuid.text == account_id:
-                        return port
+            ref_acc = el.find('referenceAccount')
+            if ref_acc is None:
+                continue
+            if ref_acc.get('reference') is not None:
+                if ref_acc.get('reference') == acc_xml_id:
+                    return el
+            else:
+                ref_uuid = ref_acc.find('uuid')
+                if ref_uuid is not None and ref_uuid.text == account_id:
+                    return el
         raise InputError(f"No portfolio linked to cash account '{account_id}'")
 
     def _find_el_by_xmlid(self, xml_id: str) -> ET.Element | None:
@@ -189,6 +197,95 @@ class PpXmlWriter:
         return txns
 
     # ─── Public API ───
+
+    def delete_transaction(self, txn_uuid: str, backup: bool = True) -> dict:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        """Delete a transaction by UUID. Handles cross-entry cleanup for transfers.
+
+        Returns a dict with details of what was deleted.
+        """
+        self._load()
+
+        # Find the element that has this UUID
+        txn_el = None
+        for el in self._root.iter():
+            uuid_sub = el.find('uuid')
+            if uuid_sub is not None and uuid_sub.text == txn_uuid:
+                txn_el = el
+                break
+
+        if txn_el is None:
+            raise InputError(f"Transaction with UUID '{txn_uuid}' not found")
+
+        ttype = txn_el.findtext('type', '?')
+        result: dict = {'uuid': txn_uuid, 'type': ttype, 'deleted': []}
+
+        # Simple (non-transfer) account transaction or portfolio transaction
+        if ttype not in ('TRANSFER_IN', 'TRANSFER_OUT'):
+            parent = txn_el.getparent()
+            if parent is not None:
+                parent.remove(txn_el)
+                result['deleted'].append(ttype)
+            self._save(backup=backup)
+            return result
+
+        # Transfer: need to remove both sides and the cross-entry
+        # Find the crossEntry from either the outer element or the inner element
+        cross = txn_el.find('crossEntry')
+        if cross is None:
+            # Inner transaction — crossEntry is referenced, find it
+            cross_ref = txn_el.find('crossEntry')
+            if cross_ref is not None:
+                ref_id = cross_ref.get('reference')
+                if ref_id:
+                    cross = self._find_el_by_xmlid(ref_id)
+
+        if cross is None:
+            # Fallback: just remove this element
+            parent = txn_el.getparent()
+            if parent is not None:
+                parent.remove(txn_el)
+                result['deleted'].append(ttype)
+            self._save(backup=backup)
+            return result
+
+        # Collect all XML IDs in this transfer cluster for reference cleanup
+        ids_to_remove: set[str] = set()
+        for el in [txn_el] + list(cross):
+            eid = el.get('id')
+            if eid:
+                ids_to_remove.add(eid)
+        cross_id = cross.get('id')
+        if cross_id:
+            ids_to_remove.add(cross_id)
+
+        # Find the outer transaction (parent of crossEntry)
+        outer_txn = cross.getparent()
+        outer_id = outer_txn.get('id') if outer_txn is not None else None
+        if outer_id:
+            ids_to_remove.add(outer_id)
+
+        # Remove all reference elements pointing to any of our IDs
+        to_remove = []
+        for el in self._root.iter():
+            ref = el.get('reference')
+            if ref and ref in ids_to_remove:
+                to_remove.append(el)
+
+        for el in to_remove:
+            parent = el.getparent()
+            if parent is not None:
+                parent.remove(el)
+                result['deleted'].append(f"ref({el.tag})")
+
+        # Remove the outer transaction (which contains crossEntry)
+        if outer_txn is not None:
+            outer_parent = outer_txn.getparent()
+            if outer_parent is not None:
+                outer_parent.remove(outer_txn)
+                result['deleted'].append(outer_txn.findtext('type', 'outer'))
+
+        self._save(backup=backup)
+        return result
 
     def add_security(
         self,
@@ -242,15 +339,18 @@ class PpXmlWriter:
         fees: float = 0.0,
         taxes: float = 0.0,
         note: str | None = None,
+        portfolio_id: str | None = None,
         backup: bool = True,
     ) -> str:
         """Add a BUY transaction. Returns the portfolio transaction UUID.
 
         Creates the cross-linked portfolio-transaction + account-transaction pair.
+        When the cash account is not the portfolio's referenceAccount (e.g.
+        multi-currency setups), pass *portfolio_id* explicitly.
         """
         return self._add_buysell(
             'BUY', security, account_id, date, shares, amount, currency,
-            fees=fees, taxes=taxes, note=note, backup=backup,
+            fees=fees, taxes=taxes, note=note, portfolio_id=portfolio_id, backup=backup,
         )
 
     def add_sell(
@@ -264,15 +364,16 @@ class PpXmlWriter:
         fees: float = 0.0,
         taxes: float = 0.0,
         note: str | None = None,
+        portfolio_id: str | None = None,
         backup: bool = True,
     ) -> str:
         """Add a SELL transaction. Returns the portfolio transaction UUID."""
         return self._add_buysell(
             'SELL', security, account_id, date, shares, amount, currency,
-            fees=fees, taxes=taxes, note=note, backup=backup,
+            fees=fees, taxes=taxes, note=note, portfolio_id=portfolio_id, backup=backup,
         )
 
-    def add_dividend(
+    def add_dividend(  # pylint: disable=too-many-locals
         self,
         security: str,
         account_id: str,
@@ -302,10 +403,9 @@ class PpXmlWriter:
         self._make_sub(txn, 'security', attribs={'reference': sec_el.get('id')})
         self._make_sub(txn, 'shares', self._shares_raw(shares))
 
-        if fees_or_taxes := (taxes > 0):
+        if taxes > 0:
             units = self._make_sub(txn, 'units')
-            if taxes > 0:
-                self._make_unit(units, 'TAX', taxes, currency)
+            self._make_unit(units, 'TAX', taxes, currency)
 
         self._make_sub(txn, 'updatedAt', now)
         self._make_sub(txn, 'type', 'DIVIDENDS')
@@ -452,17 +552,58 @@ class PpXmlWriter:
         log.info("Added INTEREST transaction (uuid=%s)", txn_uuid)
         return txn_uuid
 
-    def add_account_transfer(
+    def add_fees(
         self,
-        from_account_id: str,
-        to_account_id: str,
+        account_id: str,
         date: datetime,
         amount: float,
         currency: str,
         note: str | None = None,
         backup: bool = True,
     ) -> str:
-        """Add an account-to-account transfer. Returns the source transaction UUID."""
+        """Add a FEES transaction on a cash account. Returns the transaction UUID."""
+        return self._add_simple_account_txn(
+            'FEES', account_id, date, amount, currency, note=note, backup=backup,
+        )
+
+    def add_taxes(
+        self,
+        account_id: str,
+        date: datetime,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a TAXES transaction on a cash account. Returns the transaction UUID."""
+        return self._add_simple_account_txn(
+            'TAXES', account_id, date, amount, currency, note=note, backup=backup,
+        )
+
+    def add_account_transfer(  # pylint: disable=too-many-locals
+        self,
+        from_account_id: str,
+        to_account_id: str,
+        date: datetime,
+        amount: float,
+        currency: str,
+        to_amount: float | None = None,
+        to_currency: str | None = None,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add an account-to-account transfer. Returns the source transaction UUID.
+
+        The canonical structure mirrors PP's own XStream serialisation:
+        the outer ``account-transaction`` (TRANSFER_IN) lives in the
+        **destination** account, its nested ``crossEntry`` holds a canonical
+        ``transactionFrom`` (TRANSFER_OUT) with a back-reference to the
+        crossEntry, and the source account gets a bare reference element
+        pointing at ``transactionFrom``.
+
+        For cross-currency transfers, provide *to_amount* and *to_currency*
+        for the destination side; *amount*/*currency* are used for the source.
+        """
         self._load()
 
         from_acc = self._find_account_el(from_account_id, 'account')
@@ -475,40 +616,50 @@ class PpXmlWriter:
         from_txns = self._get_transactions_el(from_acc)
         to_txns = self._get_transactions_el(to_acc)
 
-        # Source transaction (TRANSFER_OUT)
-        from_txn = self._make_sub(from_txns, 'account-transaction', with_id=True)
+        # Resolve destination amount/currency (defaults to same as source)
+        dest_amount = to_amount if to_amount is not None else amount
+        dest_currency = to_currency if to_currency is not None else currency
+
+        # Destination transaction (TRANSFER_IN) — canonical outer element
+        to_txn = self._make_sub(to_txns, 'account-transaction', with_id=True)
+        self._make_sub(to_txn, 'uuid', to_txn_uuid)
+        self._make_sub(to_txn, 'date', self._date_iso(date))
+        self._make_sub(to_txn, 'currencyCode', dest_currency)
+        self._make_sub(to_txn, 'amount', self._amount_raw(dest_amount))
+
+        # Cross entry (nested inside the destination transaction)
+        cross = self._make_sub(to_txn, 'crossEntry', attribs={'class': 'account-transfer'}, with_id=True)
+        self._make_sub(cross, 'accountFrom', attribs={'reference': from_acc.get('id')})
+
+        # Source transaction (TRANSFER_OUT) — canonical, nested in crossEntry
+        from_txn = self._make_sub(cross, 'transactionFrom', with_id=True)
         self._make_sub(from_txn, 'uuid', from_txn_uuid)
         self._make_sub(from_txn, 'date', self._date_iso(date))
         self._make_sub(from_txn, 'currencyCode', currency)
         self._make_sub(from_txn, 'amount', self._amount_raw(amount))
-
-        # Cross entry
-        cross = self._make_sub(from_txn, 'crossEntry', attribs={'class': 'account-transfer'}, with_id=True)
-        self._make_sub(cross, 'accountFrom', attribs={'reference': from_acc.get('id')})
-        self._make_sub(cross, 'transactionFrom', attribs={'reference': from_txn.get('id')})
-        self._make_sub(cross, 'accountTo', attribs={'reference': to_acc.get('id')})
-
-        # Destination transaction (TRANSFER_IN)
-        to_txn = self._make_sub(cross, 'transactionTo', with_id=True)
-        self._make_sub(to_txn, 'uuid', to_txn_uuid)
-        self._make_sub(to_txn, 'date', self._date_iso(date))
-        self._make_sub(to_txn, 'currencyCode', currency)
-        self._make_sub(to_txn, 'amount', self._amount_raw(amount))
-        self._make_sub(to_txn, 'shares', '0')
-        self._make_sub(to_txn, 'updatedAt', now)
-        self._make_sub(to_txn, 'type', 'TRANSFER_IN')
-        if note:
-            self._make_sub(to_txn, 'note', note)
-
+        # Back-reference from inner transaction to parent crossEntry
+        self._make_sub(from_txn, 'crossEntry', attribs={
+            'class': 'account-transfer', 'reference': cross.get('id'),
+        })
         self._make_sub(from_txn, 'shares', '0')
         self._make_sub(from_txn, 'updatedAt', now)
         self._make_sub(from_txn, 'type', 'TRANSFER_OUT')
         if note:
             self._make_sub(from_txn, 'note', note)
 
-        # Reference from destination account's transactions list
-        ref_txn = self._make_sub(to_txns, 'account-transaction',
-                                 attribs={'reference': to_txn.get('id')})
+        self._make_sub(cross, 'accountTo', attribs={'reference': to_acc.get('id')})
+        # Back-reference from crossEntry to outer destination transaction
+        self._make_sub(cross, 'transactionTo', attribs={'reference': to_txn.get('id')})
+
+        self._make_sub(to_txn, 'shares', '0')
+        self._make_sub(to_txn, 'updatedAt', now)
+        self._make_sub(to_txn, 'type', 'TRANSFER_IN')
+        if note:
+            self._make_sub(to_txn, 'note', note)
+
+        # Reference from source account's transactions list to transactionFrom
+        self._make_sub(from_txns, 'account-transaction',
+                       attribs={'reference': from_txn.get('id')})
 
         self._save(backup=backup)
         log.info("Added ACCOUNT_TRANSFER (uuid=%s)", from_txn_uuid)
@@ -549,7 +700,69 @@ class PpXmlWriter:
         log.info("Added %s transaction (uuid=%s)", txn_type, txn_uuid)
         return txn_uuid
 
-    def _add_buysell(
+    def _is_ancestor_of(self, potential_ancestor: ET.Element, element: ET.Element) -> bool:
+        """Return True if *potential_ancestor* is an ancestor of *element*."""
+        parent = element.getparent()
+        while parent is not None:
+            if parent is potential_ancestor:
+                return True
+            parent = parent.getparent()
+        return False
+
+    def _pt_definition_in_portfolio(
+        self,
+        port_el: ET.Element,
+        acc_el: ET.Element,
+        port_txns: ET.Element,
+        acc_txns: ET.Element,
+    ) -> bool:
+        """Decide where the canonical portfolio-transaction definition goes.
+
+        XStream's ``ID_REFERENCES`` mode requires every ``id="N"``
+        definition to appear *before* any ``reference="N"`` in document
+        order.  For a BUY/SELL we must place one full definition in either
+        the portfolio's or the account's ``<transactions>`` list, and only
+        a back-reference in the other.
+
+        Whichever list's **closing tag** comes first in the serialised XML
+        receives the full definition; the other list receives the
+        reference.  For the common nesting patterns in PP files:
+
+        * **Account contains portfolio** (e.g. CHF account whose first transaction's
+          crossEntry defines the portfolio inline) — the portfolio's list
+          closes first → definition goes in the portfolio (return True).
+        * **Portfolio contains account** (e.g. a USD deposit account first
+          encountered inside a crossEntry nested in the portfolio's
+          transaction list) — the account's list closes first → definition
+          goes in the account (return False).
+        * **Neither nested** — whichever ``<transactions>`` element appears
+          first in document order also closes first.
+        """
+        if self._is_ancestor_of(acc_el, port_el):
+            return True
+        if self._is_ancestor_of(port_el, acc_el):
+            return False
+        # Neither nested: the element encountered first in a depth-first
+        # traversal also closes first.
+        for el in self._root.iter():
+            if el is port_txns:
+                return True
+            if el is acc_txns:
+                return False
+        return True  # fallback
+
+    def _add_buysell_units(self, parent: ET.Element, fees: float, taxes: float, currency: str) -> None:
+        """Append ``<units>`` with optional FEE / TAX children to *parent*."""
+        if fees > 0 or taxes > 0:
+            units = self._make_sub(parent, 'units')
+            if fees > 0:
+                self._make_unit(units, 'FEE', fees, currency)
+            if taxes > 0:
+                self._make_unit(units, 'TAX', taxes, currency)
+        else:
+            self._make_sub(parent, 'units')
+
+    def _add_buysell(  # pylint: disable=too-many-locals,too-many-statements
         self,
         txn_type: str,
         security: str,
@@ -561,14 +774,31 @@ class PpXmlWriter:
         fees: float = 0.0,
         taxes: float = 0.0,
         note: str | None = None,
+        portfolio_id: str | None = None,
         backup: bool = True,
     ) -> str:
-        """Create a BUY or SELL — the paired portfolio + account transaction."""
+        """Create a BUY or SELL — the paired portfolio + account transaction.
+
+        Mirrors PP's XStream serialisation: the canonical definition of
+        the full ``crossEntry`` graph (portfolio-transaction **and**
+        account-transaction) is placed in whichever ``<transactions>``
+        list closes first in document order.  The other list receives
+        only a ``reference="…"`` back-reference.  This guarantees that
+        every ``id="N"`` definition precedes any ``reference="N"`` in
+        the serialised XML, as required by XStream's ``ID_REFERENCES``
+        mode.
+        """
         self._load()
 
         sec_el = self._find_security_el(security)
         acc_el = self._find_account_el(account_id, 'account')
-        port_el = self._find_portfolio_for_account(account_id)
+        if portfolio_id:
+            port_el = self._find_account_el(portfolio_id, 'portfolio')
+        else:
+            port_el = self._find_portfolio_for_account(account_id)
+
+        port_txns = self._get_transactions_el(port_el)
+        acc_txns = self._get_transactions_el(acc_el)
 
         port_txn_uuid = self._gen_uuid()
         acc_txn_uuid = self._gen_uuid()
@@ -577,67 +807,89 @@ class PpXmlWriter:
         amount_str = self._amount_raw(amount)
         sec_ref = sec_el.get('id')
 
-        # ── Account transaction (cash side) ──
-        acc_txns = self._get_transactions_el(acc_el)
-        acc_txn = self._make_sub(acc_txns, 'account-transaction', with_id=True)
-        self._make_sub(acc_txn, 'uuid', acc_txn_uuid)
-        self._make_sub(acc_txn, 'date', date_str)
-        self._make_sub(acc_txn, 'currencyCode', currency)
-        self._make_sub(acc_txn, 'amount', amount_str)
-        self._make_sub(acc_txn, 'security', attribs={'reference': sec_ref})
+        pt_first = self._pt_definition_in_portfolio(port_el, acc_el, port_txns, acc_txns)
 
-        # ── Cross entry ──
-        cross = self._make_sub(acc_txn, 'crossEntry', attribs={'class': 'buysell'}, with_id=True)
+        if pt_first:
+            # ── Pattern A: portfolio-transaction is the canonical definition ──
+            # Matches PP's layout when the account contains the portfolio
+            # (e.g. CHF account whose crossEntry defines the portfolio inline).
+            pt = self._make_sub(port_txns, 'portfolio-transaction', with_id=True)
+            self._make_sub(pt, 'uuid', port_txn_uuid)
+            self._make_sub(pt, 'date', date_str)
+            self._make_sub(pt, 'currencyCode', currency)
+            self._make_sub(pt, 'amount', amount_str)
+            self._make_sub(pt, 'security', attribs={'reference': sec_ref})
 
-        # Portfolio reference
-        self._make_sub(cross, 'portfolio', attribs={'reference': port_el.get('id')})
+            ce = self._make_sub(pt, 'crossEntry', attribs={'class': 'buysell'}, with_id=True)
+            self._make_sub(ce, 'portfolio', attribs={'reference': port_el.get('id')})
+            self._make_sub(ce, 'portfolioTransaction', attribs={'reference': pt.get('id')})
+            self._make_sub(ce, 'account', attribs={'reference': acc_el.get('id')})
 
-        # Portfolio transaction (share side)
-        port_txn = self._make_sub(cross, 'portfolioTransaction', with_id=True)
-        self._make_sub(port_txn, 'uuid', port_txn_uuid)
-        self._make_sub(port_txn, 'date', date_str)
-        self._make_sub(port_txn, 'currencyCode', currency)
-        self._make_sub(port_txn, 'amount', amount_str)
-        self._make_sub(port_txn, 'security', attribs={'reference': sec_ref})
-        self._make_sub(port_txn, 'crossEntry', attribs={'class': 'buysell', 'reference': cross.get('id')})
-        self._make_sub(port_txn, 'shares', self._shares_raw(shares))
+            at = self._make_sub(ce, 'accountTransaction', with_id=True)
+            self._make_sub(at, 'uuid', acc_txn_uuid)
+            self._make_sub(at, 'date', date_str)
+            self._make_sub(at, 'currencyCode', currency)
+            self._make_sub(at, 'amount', amount_str)
+            self._make_sub(at, 'security', attribs={'reference': sec_ref})
+            self._make_sub(at, 'crossEntry', attribs={'class': 'buysell', 'reference': ce.get('id')})
+            self._make_sub(at, 'shares', '0')
+            self._make_sub(at, 'updatedAt', now)
+            self._make_sub(at, 'type', txn_type)
+            if note:
+                self._make_sub(at, 'note', note)
 
-        if fees > 0 or taxes > 0:
-            units = self._make_sub(port_txn, 'units')
-            if fees > 0:
-                self._make_unit(units, 'FEE', fees, currency)
-            if taxes > 0:
-                self._make_unit(units, 'TAX', taxes, currency)
+            self._make_sub(pt, 'shares', self._shares_raw(shares))
+            self._add_buysell_units(pt, fees, taxes, currency)
+            self._make_sub(pt, 'updatedAt', now)
+            self._make_sub(pt, 'type', txn_type)
+
+            self._make_sub(acc_txns, 'account-transaction',
+                           attribs={'reference': at.get('id')})
         else:
-            self._make_sub(port_txn, 'units')
+            # ── Pattern B: account-transaction is the canonical definition ──
+            # Matches PP's layout when the portfolio contains the account
+            # (e.g. a USD deposit account first defined inside a crossEntry
+            # nested in the portfolio's transaction list).
+            at = self._make_sub(acc_txns, 'account-transaction', with_id=True)
+            self._make_sub(at, 'uuid', acc_txn_uuid)
+            self._make_sub(at, 'date', date_str)
+            self._make_sub(at, 'currencyCode', currency)
+            self._make_sub(at, 'amount', amount_str)
+            self._make_sub(at, 'security', attribs={'reference': sec_ref})
 
-        self._make_sub(port_txn, 'updatedAt', now)
-        self._make_sub(port_txn, 'type', txn_type)
-        if note:
-            self._make_sub(port_txn, 'note', note)
+            ce = self._make_sub(at, 'crossEntry', attribs={'class': 'buysell'}, with_id=True)
+            self._make_sub(ce, 'portfolio', attribs={'reference': port_el.get('id')})
 
-        # Back-references in crossEntry
-        self._make_sub(cross, 'account', attribs={'reference': acc_el.get('id')})
-        self._make_sub(cross, 'accountTransaction', attribs={'reference': acc_txn.get('id')})
+            pt = self._make_sub(ce, 'portfolioTransaction', with_id=True)
+            self._make_sub(pt, 'uuid', port_txn_uuid)
+            self._make_sub(pt, 'date', date_str)
+            self._make_sub(pt, 'currencyCode', currency)
+            self._make_sub(pt, 'amount', amount_str)
+            self._make_sub(pt, 'security', attribs={'reference': sec_ref})
+            self._make_sub(pt, 'crossEntry', attribs={'class': 'buysell', 'reference': ce.get('id')})
+            self._make_sub(pt, 'shares', self._shares_raw(shares))
+            self._add_buysell_units(pt, fees, taxes, currency)
+            self._make_sub(pt, 'updatedAt', now)
+            self._make_sub(pt, 'type', txn_type)
 
-        # Finish account transaction
-        self._make_sub(acc_txn, 'shares', '0')
-        self._make_sub(acc_txn, 'updatedAt', now)
-        self._make_sub(acc_txn, 'type', txn_type)
-        if note:
-            self._make_sub(acc_txn, 'note', note)
+            self._make_sub(ce, 'account', attribs={'reference': acc_el.get('id')})
+            self._make_sub(ce, 'accountTransaction', attribs={'reference': at.get('id')})
 
-        # Add portfolio-transaction reference in portfolio's transactions list
-        port_txns = self._get_transactions_el(port_el)
-        self._make_sub(port_txns, 'portfolio-transaction',
-                       attribs={'reference': port_txn.get('id')})
+            self._make_sub(at, 'shares', '0')
+            self._make_sub(at, 'updatedAt', now)
+            self._make_sub(at, 'type', txn_type)
+            if note:
+                self._make_sub(at, 'note', note)
+
+            self._make_sub(port_txns, 'portfolio-transaction',
+                           attribs={'reference': pt.get('id')})
 
         self._save(backup=backup)
         log.info("Added %s transaction (portfolio_uuid=%s, account_uuid=%s)",
                  txn_type, port_txn_uuid, acc_txn_uuid)
         return port_txn_uuid
 
-    def _add_delivery(
+    def _add_delivery(  # pylint: disable=too-many-locals
         self,
         txn_type: str,
         security: str,

--- a/pp_terminal/data/xml_writer.py
+++ b/pp_terminal/data/xml_writer.py
@@ -1,0 +1,689 @@
+"""
+    Copyright (C) 2025-26 Daniel Gehriger
+
+    This file is part of pp-terminal.
+
+    pp-terminal is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    pp-terminal is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with pp-terminal. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import logging
+import shutil
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import lxml.etree as ET  # pylint: disable=c-extension-no-member
+
+from pp_terminal.exceptions import InputError
+
+log = logging.getLogger(__name__)
+
+# PP stores monetary amounts in 1/100 of the base unit (cents)
+_CENTS = 100
+# PP stores share counts scaled by 10^8
+_SHARE_SCALE = 10**8
+
+
+class PpXmlWriter:
+    """Writes transactions and securities into a Portfolio Performance XML file.
+
+    Operates directly on the XML DOM via lxml, preserving existing structure
+    and references. All modifications are written back to the file atomically.
+    """
+
+    def __init__(self, file_path: Path):
+        self._file_path = file_path
+        self._parser = ET.XMLParser(remove_blank_text=False, resolve_entities=False, no_network=True)
+        self._tree: ET.ElementTree | None = None
+        self._root: ET.Element | None = None
+
+    def _load(self) -> None:
+        self._tree = ET.parse(str(self._file_path), self._parser)
+        self._root = self._tree.getroot()
+
+    def _save(self, backup: bool = True) -> None:
+        if backup:
+            backup_path = self._file_path.with_suffix(self._file_path.suffix + '.bak')
+            shutil.copy2(self._file_path, backup_path)
+            log.info("Backup saved to %s", backup_path)
+
+        self._tree.write(
+            str(self._file_path),
+            encoding='UTF-8',
+            xml_declaration=True,
+            pretty_print=False,
+        )
+
+    def _next_id(self) -> int:
+        """Find the maximum id attribute in the document and return max+1."""
+        max_id = 0
+        for el in self._root.iter():
+            id_val = el.get('id')
+            if id_val is not None:
+                try:
+                    max_id = max(max_id, int(id_val))
+                except ValueError:
+                    pass
+        return max_id + 1
+
+    def _alloc_id(self) -> str:
+        """Allocate a new unique integer id, tracking allocations within a session."""
+        if not hasattr(self, '_id_counter'):
+            self._id_counter = self._next_id()
+        id_str = str(self._id_counter)
+        self._id_counter += 1
+        return id_str
+
+    @staticmethod
+    def _gen_uuid() -> str:
+        return str(uuid.uuid4())
+
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+
+    @staticmethod
+    def _date_iso(dt: datetime) -> str:
+        return dt.strftime('%Y-%m-%dT00:00')
+
+    @staticmethod
+    def _amount_raw(value: float) -> str:
+        """Convert a decimal amount (e.g. 100.50) to PP internal integer (10050)."""
+        return str(round(value * _CENTS))
+
+    @staticmethod
+    def _shares_raw(shares: float) -> str:
+        """Convert a share count to PP internal scaled integer."""
+        return str(round(shares * _SHARE_SCALE))
+
+    def _find_security_el(self, security_id: str) -> ET.Element:
+        """Find a <security> element by UUID or ISIN."""
+        for sec in self._root.findall('.//securities/security'):
+            if sec.get('reference') is not None:
+                continue
+            uuid_el = sec.find('uuid')
+            if uuid_el is not None and uuid_el.text == security_id:
+                return sec
+            isin_el = sec.find('isin')
+            if isin_el is not None and isin_el.text == security_id:
+                return sec
+        raise InputError(f"Security '{security_id}' not found")
+
+    def _find_account_el(self, account_id: str, account_type: str = 'account') -> ET.Element:
+        """Find an <account> or <portfolio> element by UUID.
+
+        Iterates the entire tree because PP XML may define elements inline
+        (e.g. a portfolio inside a crossEntry) with only a reference in the
+        top-level section.
+        """
+        tag_name = 'account' if account_type == 'account' else 'portfolio'
+        for el in self._root.iter(tag_name):
+            if el.get('reference') is not None:
+                continue
+            uuid_el = el.find('uuid')
+            if uuid_el is not None and uuid_el.text == account_id:
+                return el
+        raise InputError(f"Account '{account_id}' not found (type={account_type})")
+
+    def _find_portfolio_for_account(self, account_id: str) -> ET.Element:
+        """Find the portfolio that references the given cash account.
+
+        Iterates the entire tree because the portfolio definition may be
+        nested inside a crossEntry rather than directly under <portfolios>.
+        """
+        acc_el = self._find_account_el(account_id, 'account')
+        acc_xml_id = acc_el.get('id')
+
+        for port in self._root.iter('portfolio'):
+            if port.get('reference') is not None:
+                continue
+            ref_acc = port.find('referenceAccount')
+            if ref_acc is not None:
+                if ref_acc.get('reference') is not None:
+                    if ref_acc.get('reference') == acc_xml_id:
+                        return port
+                else:
+                    ref_uuid = ref_acc.find('uuid')
+                    if ref_uuid is not None and ref_uuid.text == account_id:
+                        return port
+        raise InputError(f"No portfolio linked to cash account '{account_id}'")
+
+    def _find_el_by_xmlid(self, xml_id: str) -> ET.Element | None:
+        """Find any element by its id attribute value."""
+        for el in self._root.iter():
+            if el.get('id') == xml_id:
+                return el
+        return None
+
+    def _make_sub(self, parent: ET.Element, tag: str, text: str | None = None,
+                  attribs: dict | None = None, with_id: bool = False) -> ET.Element:
+        el = ET.SubElement(parent, tag)
+        if with_id:
+            el.set('id', self._alloc_id())
+        if attribs:
+            for k, v in attribs.items():
+                el.set(k, str(v))
+        if text is not None:
+            el.text = text
+        return el
+
+    def _make_unit(self, parent: ET.Element, unit_type: str, amount: float, currency: str) -> None:
+        unit = self._make_sub(parent, 'unit', attribs={'type': unit_type})
+        self._make_sub(unit, 'amount', attribs={'currency': currency, 'amount': self._amount_raw(amount)})
+
+    def _get_transactions_el(self, parent: ET.Element) -> ET.Element:
+        txns = parent.find('transactions')
+        if txns is None:
+            txns = self._make_sub(parent, 'transactions')
+        return txns
+
+    # ─── Public API ───
+
+    def add_security(
+        self,
+        name: str,
+        currency: str,
+        isin: str | None = None,
+        wkn: str | None = None,
+        ticker: str | None = None,
+        feed: str = 'MANUAL',
+        backup: bool = True,
+    ) -> str:
+        """Add a new security definition. Returns the new security UUID."""
+        self._load()
+
+        sec_uuid = self._gen_uuid()
+        now = self._now_iso()
+        securities = self._root.find('securities')
+        if securities is None:
+            raise InputError("Invalid PP XML: missing <securities> element")
+
+        sec = self._make_sub(securities, 'security', with_id=True)
+        self._make_sub(sec, 'uuid', sec_uuid)
+        self._make_sub(sec, 'name', name)
+        self._make_sub(sec, 'currencyCode', currency)
+        if isin:
+            self._make_sub(sec, 'isin', isin)
+        if ticker:
+            self._make_sub(sec, 'tickerSymbol', ticker)
+        if wkn:
+            self._make_sub(sec, 'wkn', wkn)
+        self._make_sub(sec, 'feed', feed)
+        self._make_sub(sec, 'prices')
+        self._make_sub(sec, 'events')
+        attrs = self._make_sub(sec, 'attributes')
+        self._make_sub(attrs, 'map')
+        self._make_sub(sec, 'isRetired', 'false')
+        self._make_sub(sec, 'updatedAt', now)
+
+        self._save(backup=backup)
+        log.info("Added security '%s' (uuid=%s)", name, sec_uuid)
+        return sec_uuid
+
+    def add_buy(
+        self,
+        security: str,
+        account_id: str,
+        date: datetime,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a BUY transaction. Returns the portfolio transaction UUID.
+
+        Creates the cross-linked portfolio-transaction + account-transaction pair.
+        """
+        return self._add_buysell(
+            'BUY', security, account_id, date, shares, amount, currency,
+            fees=fees, taxes=taxes, note=note, backup=backup,
+        )
+
+    def add_sell(
+        self,
+        security: str,
+        account_id: str,
+        date: datetime,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a SELL transaction. Returns the portfolio transaction UUID."""
+        return self._add_buysell(
+            'SELL', security, account_id, date, shares, amount, currency,
+            fees=fees, taxes=taxes, note=note, backup=backup,
+        )
+
+    def add_dividend(
+        self,
+        security: str,
+        account_id: str,
+        date: datetime,
+        amount: float,
+        currency: str,
+        shares: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a DIVIDENDS transaction on a cash account. Returns the transaction UUID."""
+        self._load()
+
+        sec_el = self._find_security_el(security)
+        acc_el = self._find_account_el(account_id, 'account')
+        txns = self._get_transactions_el(acc_el)
+
+        txn_uuid = self._gen_uuid()
+        now = self._now_iso()
+
+        txn = self._make_sub(txns, 'account-transaction', with_id=True)
+        self._make_sub(txn, 'uuid', txn_uuid)
+        self._make_sub(txn, 'date', self._date_iso(date))
+        self._make_sub(txn, 'currencyCode', currency)
+        self._make_sub(txn, 'amount', self._amount_raw(amount))
+        self._make_sub(txn, 'security', attribs={'reference': sec_el.get('id')})
+        self._make_sub(txn, 'shares', self._shares_raw(shares))
+
+        if fees_or_taxes := (taxes > 0):
+            units = self._make_sub(txn, 'units')
+            if taxes > 0:
+                self._make_unit(units, 'TAX', taxes, currency)
+
+        self._make_sub(txn, 'updatedAt', now)
+        self._make_sub(txn, 'type', 'DIVIDENDS')
+        if note:
+            self._make_sub(txn, 'note', note)
+
+        self._save(backup=backup)
+        log.info("Added DIVIDENDS transaction (uuid=%s)", txn_uuid)
+        return txn_uuid
+
+    def add_deposit(
+        self,
+        account_id: str,
+        date: datetime,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a DEPOSIT transaction. Returns the transaction UUID."""
+        return self._add_simple_account_txn(
+            'DEPOSIT', account_id, date, amount, currency, note=note, backup=backup,
+        )
+
+    def add_withdrawal(
+        self,
+        account_id: str,
+        date: datetime,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a REMOVAL transaction. Returns the transaction UUID."""
+        return self._add_simple_account_txn(
+            'REMOVAL', account_id, date, amount, currency, note=note, backup=backup,
+        )
+
+    def add_stock_split(
+        self,
+        security: str,
+        date: datetime,
+        ratio: str,
+        backup: bool = True,
+    ) -> None:
+        """Add a stock split event to a security.
+
+        Args:
+            security: ISIN or UUID of the security
+            date: Date of the split
+            ratio: Split ratio as string, e.g. '4:1' for a 4-for-1 split
+            backup: Create .bak backup before writing
+        """
+        self._load()
+        sec_el = self._find_security_el(security)
+
+        events = sec_el.find('events')
+        if events is None:
+            events = self._make_sub(sec_el, 'events')
+
+        event = self._make_sub(events, 'event')
+        self._make_sub(event, 'date', self._date_iso(date))
+        self._make_sub(event, 'type', 'STOCK_SPLIT')
+        self._make_sub(event, 'details', ratio)
+
+        self._save(backup=backup)
+        log.info("Added STOCK_SPLIT event for security '%s' (ratio=%s)", security, ratio)
+
+    def add_delivery_inbound(
+        self,
+        security: str,
+        portfolio_id: str,
+        date: datetime,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a DELIVERY_INBOUND transaction (shares delivered into a portfolio without a cash leg).
+        Returns the portfolio transaction UUID."""
+        return self._add_delivery(
+            'DELIVERY_INBOUND', security, portfolio_id, date, shares, amount, currency,
+            fees=fees, taxes=taxes, note=note, backup=backup,
+        )
+
+    def add_delivery_outbound(
+        self,
+        security: str,
+        portfolio_id: str,
+        date: datetime,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a DELIVERY_OUTBOUND transaction (shares removed from a portfolio without a cash leg).
+        Returns the portfolio transaction UUID."""
+        return self._add_delivery(
+            'DELIVERY_OUTBOUND', security, portfolio_id, date, shares, amount, currency,
+            fees=fees, taxes=taxes, note=note, backup=backup,
+        )
+
+    def add_interest(
+        self,
+        account_id: str,
+        date: datetime,
+        amount: float,
+        currency: str,
+        taxes: float = 0.0,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add an INTEREST transaction on a cash account. Returns the transaction UUID."""
+        self._load()
+        acc_el = self._find_account_el(account_id, 'account')
+        txns = self._get_transactions_el(acc_el)
+
+        txn_uuid = self._gen_uuid()
+        now = self._now_iso()
+
+        txn = self._make_sub(txns, 'account-transaction', with_id=True)
+        self._make_sub(txn, 'uuid', txn_uuid)
+        self._make_sub(txn, 'date', self._date_iso(date))
+        self._make_sub(txn, 'currencyCode', currency)
+        self._make_sub(txn, 'amount', self._amount_raw(amount))
+        self._make_sub(txn, 'shares', '0')
+
+        if taxes > 0:
+            units = self._make_sub(txn, 'units')
+            self._make_unit(units, 'TAX', taxes, currency)
+
+        self._make_sub(txn, 'updatedAt', now)
+        self._make_sub(txn, 'type', 'INTEREST')
+        if note:
+            self._make_sub(txn, 'note', note)
+
+        self._save(backup=backup)
+        log.info("Added INTEREST transaction (uuid=%s)", txn_uuid)
+        return txn_uuid
+
+    def add_account_transfer(
+        self,
+        from_account_id: str,
+        to_account_id: str,
+        date: datetime,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add an account-to-account transfer. Returns the source transaction UUID."""
+        self._load()
+
+        from_acc = self._find_account_el(from_account_id, 'account')
+        to_acc = self._find_account_el(to_account_id, 'account')
+
+        from_txn_uuid = self._gen_uuid()
+        to_txn_uuid = self._gen_uuid()
+        now = self._now_iso()
+
+        from_txns = self._get_transactions_el(from_acc)
+        to_txns = self._get_transactions_el(to_acc)
+
+        # Source transaction (TRANSFER_OUT)
+        from_txn = self._make_sub(from_txns, 'account-transaction', with_id=True)
+        self._make_sub(from_txn, 'uuid', from_txn_uuid)
+        self._make_sub(from_txn, 'date', self._date_iso(date))
+        self._make_sub(from_txn, 'currencyCode', currency)
+        self._make_sub(from_txn, 'amount', self._amount_raw(amount))
+
+        # Cross entry
+        cross = self._make_sub(from_txn, 'crossEntry', attribs={'class': 'account-transfer'}, with_id=True)
+        self._make_sub(cross, 'accountFrom', attribs={'reference': from_acc.get('id')})
+        self._make_sub(cross, 'transactionFrom', attribs={'reference': from_txn.get('id')})
+        self._make_sub(cross, 'accountTo', attribs={'reference': to_acc.get('id')})
+
+        # Destination transaction (TRANSFER_IN)
+        to_txn = self._make_sub(cross, 'transactionTo', with_id=True)
+        self._make_sub(to_txn, 'uuid', to_txn_uuid)
+        self._make_sub(to_txn, 'date', self._date_iso(date))
+        self._make_sub(to_txn, 'currencyCode', currency)
+        self._make_sub(to_txn, 'amount', self._amount_raw(amount))
+        self._make_sub(to_txn, 'shares', '0')
+        self._make_sub(to_txn, 'updatedAt', now)
+        self._make_sub(to_txn, 'type', 'TRANSFER_IN')
+        if note:
+            self._make_sub(to_txn, 'note', note)
+
+        self._make_sub(from_txn, 'shares', '0')
+        self._make_sub(from_txn, 'updatedAt', now)
+        self._make_sub(from_txn, 'type', 'TRANSFER_OUT')
+        if note:
+            self._make_sub(from_txn, 'note', note)
+
+        # Reference from destination account's transactions list
+        ref_txn = self._make_sub(to_txns, 'account-transaction',
+                                 attribs={'reference': to_txn.get('id')})
+
+        self._save(backup=backup)
+        log.info("Added ACCOUNT_TRANSFER (uuid=%s)", from_txn_uuid)
+        return from_txn_uuid
+
+    # ─── Private helpers ───
+
+    def _add_simple_account_txn(
+        self,
+        txn_type: str,
+        account_id: str,
+        date: datetime,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        self._load()
+
+        acc_el = self._find_account_el(account_id, 'account')
+        txns = self._get_transactions_el(acc_el)
+
+        txn_uuid = self._gen_uuid()
+        now = self._now_iso()
+
+        txn = self._make_sub(txns, 'account-transaction', with_id=True)
+        self._make_sub(txn, 'uuid', txn_uuid)
+        self._make_sub(txn, 'date', self._date_iso(date))
+        self._make_sub(txn, 'currencyCode', currency)
+        self._make_sub(txn, 'amount', self._amount_raw(amount))
+        self._make_sub(txn, 'shares', '0')
+        self._make_sub(txn, 'updatedAt', now)
+        self._make_sub(txn, 'type', txn_type)
+        if note:
+            self._make_sub(txn, 'note', note)
+
+        self._save(backup=backup)
+        log.info("Added %s transaction (uuid=%s)", txn_type, txn_uuid)
+        return txn_uuid
+
+    def _add_buysell(
+        self,
+        txn_type: str,
+        security: str,
+        account_id: str,
+        date: datetime,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Create a BUY or SELL — the paired portfolio + account transaction."""
+        self._load()
+
+        sec_el = self._find_security_el(security)
+        acc_el = self._find_account_el(account_id, 'account')
+        port_el = self._find_portfolio_for_account(account_id)
+
+        port_txn_uuid = self._gen_uuid()
+        acc_txn_uuid = self._gen_uuid()
+        now = self._now_iso()
+        date_str = self._date_iso(date)
+        amount_str = self._amount_raw(amount)
+        sec_ref = sec_el.get('id')
+
+        # ── Account transaction (cash side) ──
+        acc_txns = self._get_transactions_el(acc_el)
+        acc_txn = self._make_sub(acc_txns, 'account-transaction', with_id=True)
+        self._make_sub(acc_txn, 'uuid', acc_txn_uuid)
+        self._make_sub(acc_txn, 'date', date_str)
+        self._make_sub(acc_txn, 'currencyCode', currency)
+        self._make_sub(acc_txn, 'amount', amount_str)
+        self._make_sub(acc_txn, 'security', attribs={'reference': sec_ref})
+
+        # ── Cross entry ──
+        cross = self._make_sub(acc_txn, 'crossEntry', attribs={'class': 'buysell'}, with_id=True)
+
+        # Portfolio reference
+        self._make_sub(cross, 'portfolio', attribs={'reference': port_el.get('id')})
+
+        # Portfolio transaction (share side)
+        port_txn = self._make_sub(cross, 'portfolioTransaction', with_id=True)
+        self._make_sub(port_txn, 'uuid', port_txn_uuid)
+        self._make_sub(port_txn, 'date', date_str)
+        self._make_sub(port_txn, 'currencyCode', currency)
+        self._make_sub(port_txn, 'amount', amount_str)
+        self._make_sub(port_txn, 'security', attribs={'reference': sec_ref})
+        self._make_sub(port_txn, 'crossEntry', attribs={'class': 'buysell', 'reference': cross.get('id')})
+        self._make_sub(port_txn, 'shares', self._shares_raw(shares))
+
+        if fees > 0 or taxes > 0:
+            units = self._make_sub(port_txn, 'units')
+            if fees > 0:
+                self._make_unit(units, 'FEE', fees, currency)
+            if taxes > 0:
+                self._make_unit(units, 'TAX', taxes, currency)
+        else:
+            self._make_sub(port_txn, 'units')
+
+        self._make_sub(port_txn, 'updatedAt', now)
+        self._make_sub(port_txn, 'type', txn_type)
+        if note:
+            self._make_sub(port_txn, 'note', note)
+
+        # Back-references in crossEntry
+        self._make_sub(cross, 'account', attribs={'reference': acc_el.get('id')})
+        self._make_sub(cross, 'accountTransaction', attribs={'reference': acc_txn.get('id')})
+
+        # Finish account transaction
+        self._make_sub(acc_txn, 'shares', '0')
+        self._make_sub(acc_txn, 'updatedAt', now)
+        self._make_sub(acc_txn, 'type', txn_type)
+        if note:
+            self._make_sub(acc_txn, 'note', note)
+
+        # Add portfolio-transaction reference in portfolio's transactions list
+        port_txns = self._get_transactions_el(port_el)
+        self._make_sub(port_txns, 'portfolio-transaction',
+                       attribs={'reference': port_txn.get('id')})
+
+        self._save(backup=backup)
+        log.info("Added %s transaction (portfolio_uuid=%s, account_uuid=%s)",
+                 txn_type, port_txn_uuid, acc_txn_uuid)
+        return port_txn_uuid
+
+    def _add_delivery(
+        self,
+        txn_type: str,
+        security: str,
+        portfolio_id: str,
+        date: datetime,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+        backup: bool = True,
+    ) -> str:
+        """Add a DELIVERY_INBOUND or DELIVERY_OUTBOUND (no cash leg)."""
+        self._load()
+
+        sec_el = self._find_security_el(security)
+        port_el = self._find_account_el(portfolio_id, 'portfolio')
+
+        txn_uuid = self._gen_uuid()
+        now = self._now_iso()
+
+        port_txns = self._get_transactions_el(port_el)
+
+        txn = self._make_sub(port_txns, 'portfolio-transaction', with_id=True)
+        self._make_sub(txn, 'uuid', txn_uuid)
+        self._make_sub(txn, 'date', self._date_iso(date))
+        self._make_sub(txn, 'currencyCode', currency)
+        self._make_sub(txn, 'amount', self._amount_raw(amount))
+        self._make_sub(txn, 'security', attribs={'reference': sec_el.get('id')})
+        self._make_sub(txn, 'shares', self._shares_raw(shares))
+
+        if fees > 0 or taxes > 0:
+            units = self._make_sub(txn, 'units')
+            if fees > 0:
+                self._make_unit(units, 'FEE', fees, currency)
+            if taxes > 0:
+                self._make_unit(units, 'TAX', taxes, currency)
+        else:
+            self._make_sub(txn, 'units')
+
+        self._make_sub(txn, 'updatedAt', now)
+        self._make_sub(txn, 'type', txn_type)
+        if note:
+            self._make_sub(txn, 'note', note)
+
+        self._save(backup=backup)
+        log.info("Added %s transaction (uuid=%s)", txn_type, txn_uuid)
+        return txn_uuid

--- a/pp_terminal/main.py
+++ b/pp_terminal/main.py
@@ -45,6 +45,7 @@ from . import __version__
 app = typer.Typer(no_args_is_help=True, rich_markup_mode="rich")
 app.add_typer(typer.Typer(no_args_is_help=True), name="simulate", help="Run simulations on the portfolio data, like share sells or German Vorabpauschale.")
 app.add_typer(typer.Typer(no_args_is_help=True), name="view", help="View details about portfolio entities like accounts or securities.")
+app.add_typer(typer.Typer(no_args_is_help=True), name="import", help="Import transactions, securities, and events into the Portfolio Performance XML file.")
 
 # init default logging (this is e.g. import for errors during command plugin load)
 logging.basicConfig(level=logging.WARN, format="%(message)s", datefmt="[%X]", handlers=[RichHandler(rich_tracebacks=False, show_time=False, show_path=False)])

--- a/pp_terminal/mcp_server.py
+++ b/pp_terminal/mcp_server.py
@@ -41,6 +41,7 @@ from pp_terminal.exceptions import InputError
 from pp_terminal.utils.cache import checksum
 from pp_terminal.domain.portfolio_snapshot import PortfolioSnapshot
 from pp_terminal.domain.vap import calculate_vap, get_base_rate_for_year, add_account_balances
+from pp_terminal.data.xml_writer import PpXmlWriter
 from pp_terminal.utils.config import Config, get_tax_rate, get_exempt_rate, get_exempt_rate_attribute, get_tax_files
 
 log = logging.getLogger(__name__)
@@ -49,7 +50,7 @@ _MCP_INSTRUCTIONS = """Portfolio Performance analytics server for a single portf
 
 Workflow:
 1. Use query_securities or query_accounts to discover holdings, IDs, and balances.
-2. Use the appropriate analysis tool (see tool selection guide below).
+2. Use the appropriate analysis or import tool (see tool selection guide below).
 
 Tool selection guide:
 - "Show my holdings" / "What securities do I have?" → query_securities
@@ -60,12 +61,25 @@ Tool selection guide:
 - "What if I sell N shares of X?" → simulate_sell_shares
 - "Show FIFO lots for X" / "Purchase history for X" → query_fifo_lots
 - "Calculate Vorabpauschale" / "VAP for year X" → simulate_vap
+- "Add a new security/ETF" → import_security
+- "Record a buy/purchase" → import_buy
+- "Record a sale" → import_sell
+- "Record a dividend" → import_dividend
+- "Record a deposit/withdrawal" → import_deposit / import_withdrawal
+- "Record a stock split" → import_stock_split
+- "Transfer cash between accounts" → import_account_transfer
+- "Record share delivery" → import_delivery_inbound / import_delivery_outbound
+- "Record interest payment" → import_interest
 
 The sell/FIFO tools accept a 'security' parameter that can be either an ISIN (e.g. 'IE00B4L5Y983')
 or an internal securityId UUID. Prefer ISIN when available.
 
 All dates are ISO format strings (e.g. '2025-06-15'). All monetary amounts are in the security's
 native currency. Tax rates are in percent (e.g. 26.375 for German Abgeltungssteuer + Soli).
+
+Import tools modify the Portfolio Performance XML file directly. A .bak backup is always created
+before writing. After any import, the in-memory portfolio is automatically refreshed.
+Amounts for import tools are in the currency's base unit (e.g. EUR, not cents).
 """
 
 _SUMMARY_COLUMNS = ['securityName', 'currency', 'shares', 'salePrice', 'costBasis',
@@ -370,6 +384,318 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
             security_id, account_id, target_net=target_net, tax_csv_data=tax_csv_data
         )
         return _clean_records(result) if not result.empty else []
+
+    # ─── Import tools (write to XML) ───
+
+    def _writer() -> PpXmlWriter:
+        return PpXmlWriter(file_path)
+
+    def _invalidate_portfolio() -> None:
+        state['checksum'] = ''
+
+    @mcp.tool()
+    def import_security(
+        name: str,
+        currency: str,
+        isin: str | None = None,
+        wkn: str | None = None,
+        ticker: str | None = None,
+        feed: str = 'MANUAL',
+    ) -> dict[str, str]:
+        """Add a new security definition to the portfolio.
+
+        Args:
+            name: Display name (e.g. 'Vanguard FTSE All-World')
+            currency: Trading currency (e.g. 'EUR', 'USD')
+            isin: ISIN identifier (e.g. 'IE00B4L5Y983')
+            wkn: WKN identifier
+            ticker: Ticker symbol (e.g. 'VWCE.DE')
+            feed: Price feed source (defaults to 'MANUAL')
+        """
+        sec_uuid = _writer().add_security(name, currency, isin=isin, wkn=wkn, ticker=ticker, feed=feed)
+        _invalidate_portfolio()
+        return {'securityId': sec_uuid, 'name': name, 'status': 'created'}
+
+    @mcp.tool()
+    def import_buy(
+        security: str,
+        account_id: str,
+        date: str,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record a BUY transaction (purchase shares via a cash account).
+
+        Creates the cross-linked portfolio + account transaction pair.
+        Use query_accounts(account_type='DEPOSIT') to find cash account IDs.
+        The portfolio linked to this cash account is found automatically.
+
+        Args:
+            security: ISIN (e.g. 'IE00B4L5Y983') or securityId UUID
+            account_id: Cash account UUID (from query_accounts)
+            date: Transaction date as ISO string (e.g. '2025-01-15')
+            shares: Number of shares purchased
+            amount: Total transaction amount in base currency units (e.g. 1000.50 for EUR 1000.50)
+            currency: Transaction currency (e.g. 'EUR')
+            fees: Transaction fees in currency units (default 0)
+            taxes: Transaction taxes in currency units (default 0)
+            note: Optional transaction note
+        """
+        txn_uuid = _writer().add_buy(
+            security, account_id, datetime.fromisoformat(date),
+            shares, amount, currency, fees=fees, taxes=taxes, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'BUY', 'status': 'created'}
+
+    @mcp.tool()
+    def import_sell(
+        security: str,
+        account_id: str,
+        date: str,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record a SELL transaction (sell shares, proceeds go to cash account).
+
+        Args:
+            security: ISIN or securityId UUID
+            account_id: Cash account UUID
+            date: Transaction date as ISO string (e.g. '2025-01-15')
+            shares: Number of shares sold
+            amount: Total proceeds in currency units (e.g. 1500.00)
+            currency: Transaction currency (e.g. 'EUR')
+            fees: Transaction fees (default 0)
+            taxes: Transaction taxes (default 0)
+            note: Optional transaction note
+        """
+        txn_uuid = _writer().add_sell(
+            security, account_id, datetime.fromisoformat(date),
+            shares, amount, currency, fees=fees, taxes=taxes, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'SELL', 'status': 'created'}
+
+    @mcp.tool()
+    def import_dividend(
+        security: str,
+        account_id: str,
+        date: str,
+        amount: float,
+        currency: str,
+        shares: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record a DIVIDEND payment received into a cash account.
+
+        Args:
+            security: ISIN or securityId UUID
+            account_id: Cash account UUID where dividend was received
+            date: Payment date as ISO string
+            amount: Net dividend amount received in currency units
+            currency: Payment currency (e.g. 'EUR')
+            shares: Number of shares at ex-dividend date (informational)
+            taxes: Withholding taxes in currency units (default 0)
+            note: Optional note
+        """
+        txn_uuid = _writer().add_dividend(
+            security, account_id, datetime.fromisoformat(date),
+            amount, currency, shares=shares, taxes=taxes, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'DIVIDENDS', 'status': 'created'}
+
+    @mcp.tool()
+    def import_deposit(
+        account_id: str,
+        date: str,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record a cash DEPOSIT into an account.
+
+        Args:
+            account_id: Cash account UUID
+            date: Deposit date as ISO string
+            amount: Deposit amount in currency units
+            currency: Currency (e.g. 'EUR')
+            note: Optional note
+        """
+        txn_uuid = _writer().add_deposit(
+            account_id, datetime.fromisoformat(date), amount, currency, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'DEPOSIT', 'status': 'created'}
+
+    @mcp.tool()
+    def import_withdrawal(
+        account_id: str,
+        date: str,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record a cash WITHDRAWAL (removal) from an account.
+
+        Args:
+            account_id: Cash account UUID
+            date: Withdrawal date as ISO string
+            amount: Withdrawal amount in currency units
+            currency: Currency (e.g. 'EUR')
+            note: Optional note
+        """
+        txn_uuid = _writer().add_withdrawal(
+            account_id, datetime.fromisoformat(date), amount, currency, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'REMOVAL', 'status': 'created'}
+
+    @mcp.tool()
+    def import_stock_split(
+        security: str,
+        date: str,
+        ratio: str,
+    ) -> dict[str, str]:
+        """Record a STOCK_SPLIT event on a security.
+
+        Args:
+            security: ISIN or securityId UUID
+            date: Split date as ISO string
+            ratio: Split ratio (e.g. '4:1' for a 4-for-1 split, '1:10' for a reverse split)
+        """
+        _writer().add_stock_split(security, datetime.fromisoformat(date), ratio)
+        _invalidate_portfolio()
+        return {'security': security, 'type': 'STOCK_SPLIT', 'ratio': ratio, 'status': 'created'}
+
+    @mcp.tool()
+    def import_delivery_inbound(
+        security: str,
+        portfolio_id: str,
+        date: str,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record a DELIVERY_INBOUND — shares transferred into a portfolio without a cash leg.
+
+        Use for share transfers from another broker, inheritance, gifts, etc.
+
+        Args:
+            security: ISIN or securityId UUID
+            portfolio_id: Securities account (portfolio) UUID
+            date: Delivery date as ISO string
+            shares: Number of shares delivered
+            amount: Market value at delivery in currency units
+            currency: Currency (e.g. 'EUR')
+            fees: Fees (default 0)
+            taxes: Taxes (default 0)
+            note: Optional note
+        """
+        txn_uuid = _writer().add_delivery_inbound(
+            security, portfolio_id, datetime.fromisoformat(date),
+            shares, amount, currency, fees=fees, taxes=taxes, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'DELIVERY_INBOUND', 'status': 'created'}
+
+    @mcp.tool()
+    def import_delivery_outbound(
+        security: str,
+        portfolio_id: str,
+        date: str,
+        shares: float,
+        amount: float,
+        currency: str,
+        fees: float = 0.0,
+        taxes: float = 0.0,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record a DELIVERY_OUTBOUND — shares removed from a portfolio without a cash leg.
+
+        Use for share transfers to another broker, gifts out, etc.
+
+        Args:
+            security: ISIN or securityId UUID
+            portfolio_id: Securities account (portfolio) UUID
+            date: Delivery date as ISO string
+            shares: Number of shares removed
+            amount: Market value at removal in currency units
+            currency: Currency (e.g. 'EUR')
+            fees: Fees (default 0)
+            taxes: Taxes (default 0)
+            note: Optional note
+        """
+        txn_uuid = _writer().add_delivery_outbound(
+            security, portfolio_id, datetime.fromisoformat(date),
+            shares, amount, currency, fees=fees, taxes=taxes, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'DELIVERY_OUTBOUND', 'status': 'created'}
+
+    @mcp.tool()
+    def import_interest(
+        account_id: str,
+        date: str,
+        amount: float,
+        currency: str,
+        taxes: float = 0.0,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record an INTEREST payment received on a cash account.
+
+        Args:
+            account_id: Cash account UUID
+            date: Payment date as ISO string
+            amount: Interest amount in currency units
+            currency: Currency (e.g. 'EUR')
+            taxes: Withholding taxes (default 0)
+            note: Optional note
+        """
+        txn_uuid = _writer().add_interest(
+            account_id, datetime.fromisoformat(date),
+            amount, currency, taxes=taxes, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'INTEREST', 'status': 'created'}
+
+    @mcp.tool()
+    def import_account_transfer(
+        from_account_id: str,
+        to_account_id: str,
+        date: str,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Transfer cash between two deposit accounts.
+
+        Args:
+            from_account_id: Source cash account UUID
+            to_account_id: Destination cash account UUID
+            date: Transfer date as ISO string
+            amount: Transfer amount in currency units
+            currency: Currency (e.g. 'EUR')
+            note: Optional note
+        """
+        txn_uuid = _writer().add_account_transfer(
+            from_account_id, to_account_id, datetime.fromisoformat(date),
+            amount, currency, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'ACCOUNT_TRANSFER', 'status': 'created'}
 
     return mcp
 

--- a/pp_terminal/mcp_server.py
+++ b/pp_terminal/mcp_server.py
@@ -396,7 +396,7 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
     @mcp.tool()
     def delete_transaction(
         transaction_uuid: str,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Delete a transaction by its UUID.
 
         Handles cross-entry cleanup for transfer transactions (removes both sides).

--- a/pp_terminal/mcp_server.py
+++ b/pp_terminal/mcp_server.py
@@ -394,7 +394,23 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         state['checksum'] = ''
 
     @mcp.tool()
-    def import_security(
+    def delete_transaction(
+        transaction_uuid: str,
+    ) -> dict:
+        """Delete a transaction by its UUID.
+
+        Handles cross-entry cleanup for transfer transactions (removes both sides).
+        Use query_accounts or query_securities to find transaction UUIDs.
+
+        Args:
+            transaction_uuid: The UUID of the transaction to delete
+        """
+        result = _writer().delete_transaction(transaction_uuid)
+        _invalidate_portfolio()
+        return result
+
+    @mcp.tool()
+    def import_security(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         name: str,
         currency: str,
         isin: str | None = None,
@@ -417,7 +433,7 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         return {'securityId': sec_uuid, 'name': name, 'status': 'created'}
 
     @mcp.tool()
-    def import_buy(
+    def import_buy(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         security: str,
         account_id: str,
         date: str,
@@ -453,7 +469,7 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         return {'transactionId': txn_uuid, 'type': 'BUY', 'status': 'created'}
 
     @mcp.tool()
-    def import_sell(
+    def import_sell(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         security: str,
         account_id: str,
         date: str,
@@ -485,7 +501,7 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         return {'transactionId': txn_uuid, 'type': 'SELL', 'status': 'created'}
 
     @mcp.tool()
-    def import_dividend(
+    def import_dividend(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         security: str,
         account_id: str,
         date: str,
@@ -578,7 +594,7 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         return {'security': security, 'type': 'STOCK_SPLIT', 'ratio': ratio, 'status': 'created'}
 
     @mcp.tool()
-    def import_delivery_inbound(
+    def import_delivery_inbound(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         security: str,
         portfolio_id: str,
         date: str,
@@ -612,7 +628,7 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         return {'transactionId': txn_uuid, 'type': 'DELIVERY_INBOUND', 'status': 'created'}
 
     @mcp.tool()
-    def import_delivery_outbound(
+    def import_delivery_outbound(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         security: str,
         portfolio_id: str,
         date: str,
@@ -646,7 +662,7 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         return {'transactionId': txn_uuid, 'type': 'DELIVERY_OUTBOUND', 'status': 'created'}
 
     @mcp.tool()
-    def import_interest(
+    def import_interest(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         account_id: str,
         date: str,
         amount: float,
@@ -672,27 +688,84 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         return {'transactionId': txn_uuid, 'type': 'INTEREST', 'status': 'created'}
 
     @mcp.tool()
-    def import_account_transfer(
-        from_account_id: str,
-        to_account_id: str,
+    def import_fees(
+        account_id: str,
         date: str,
         amount: float,
         currency: str,
         note: str | None = None,
     ) -> dict[str, str]:
+        """Record a FEES (fee payment) on a cash account.
+
+        Args:
+            account_id: Cash account UUID
+            date: Fee date as ISO string
+            amount: Fee amount in currency units
+            currency: Currency (e.g. 'EUR')
+            note: Optional note
+        """
+        txn_uuid = _writer().add_fees(
+            account_id, datetime.fromisoformat(date),
+            amount, currency, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'FEES', 'status': 'created'}
+
+    @mcp.tool()
+    def import_taxes(
+        account_id: str,
+        date: str,
+        amount: float,
+        currency: str,
+        note: str | None = None,
+    ) -> dict[str, str]:
+        """Record a TAXES (tax payment) on a cash account.
+
+        Args:
+            account_id: Cash account UUID
+            date: Tax payment date as ISO string
+            amount: Tax amount in currency units
+            currency: Currency (e.g. 'EUR')
+            note: Optional note
+        """
+        txn_uuid = _writer().add_taxes(
+            account_id, datetime.fromisoformat(date),
+            amount, currency, note=note,
+        )
+        _invalidate_portfolio()
+        return {'transactionId': txn_uuid, 'type': 'TAXES', 'status': 'created'}
+
+    @mcp.tool()
+    def import_account_transfer(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        from_account_id: str,
+        to_account_id: str,
+        date: str,
+        amount: float,
+        currency: str,
+        to_amount: float | None = None,
+        to_currency: str | None = None,
+        note: str | None = None,
+    ) -> dict[str, str]:
         """Transfer cash between two deposit accounts.
+
+        For same-currency transfers, provide amount and currency.
+        For cross-currency (FX) transfers, also provide to_amount and to_currency
+        for the destination side.
 
         Args:
             from_account_id: Source cash account UUID
             to_account_id: Destination cash account UUID
             date: Transfer date as ISO string
-            amount: Transfer amount in currency units
-            currency: Currency (e.g. 'EUR')
+            amount: Source amount in currency units
+            currency: Source currency (e.g. 'CHF')
+            to_amount: Destination amount (for cross-currency transfers)
+            to_currency: Destination currency (for cross-currency transfers)
             note: Optional note
         """
         txn_uuid = _writer().add_account_transfer(
             from_account_id, to_account_id, datetime.fromisoformat(date),
-            amount, currency, note=note,
+            amount, currency, to_amount=to_amount, to_currency=to_currency,
+            note=note,
         )
         _invalidate_portfolio()
         return {'transactionId': txn_uuid, 'type': 'ACCOUNT_TRANSFER', 'status': 'created'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "mcp (>=1.0.0,<2.0.0)",
 ]
 scripts = { pp-terminal = "pp_terminal.main:app" }
-entry-points = { "pp_terminal.commands" = { "view.accounts" = "pp_terminal.commands.view_accounts:app", "view.securities" = "pp_terminal.commands.view_securities:app", "view.taxonomies" = "pp_terminal.commands.view_taxonomies:app", "simulate.vorabpauschale" = "pp_terminal.commands.simulate_vap:app", "simulate.interest" = "pp_terminal.commands.simulate_interest:app", "simulate.share-sell" = "pp_terminal.commands.simulate_share_sell:app", "validate" = "pp_terminal.commands.validate:app", "export" = "pp_terminal.commands.export:app" } }
+entry-points = { "pp_terminal.commands" = { "view.accounts" = "pp_terminal.commands.view_accounts:app", "view.securities" = "pp_terminal.commands.view_securities:app", "view.taxonomies" = "pp_terminal.commands.view_taxonomies:app", "simulate.vorabpauschale" = "pp_terminal.commands.simulate_vap:app", "simulate.interest" = "pp_terminal.commands.simulate_interest:app", "simulate.share-sell" = "pp_terminal.commands.simulate_share_sell:app", "validate" = "pp_terminal.commands.validate:app", "export" = "pp_terminal.commands.export:app", "import.data" = "pp_terminal.commands.import_data:app" } }
 dynamic = ["version"]
 
 

--- a/tests/commands/test_roundtrip_import.py
+++ b/tests/commands/test_roundtrip_import.py
@@ -1,0 +1,392 @@
+"""Round-trip integration test: write via PpXmlWriter, read back via ppxml2db -> PpPortfolioBuilder.
+
+Verifies that every transaction type survives the full write -> parse -> query cycle.
+"""
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pp_terminal.data.pp_portfolio_builder import PpPortfolioBuilder
+from pp_terminal.data.xml_writer import PpXmlWriter
+from pp_terminal.domain.schemas import TransactionType, AccountType
+from pp_terminal.main import app
+
+FIXTURES = Path(__file__).parent.parent / 'fixtures'
+
+
+@pytest.fixture
+def writable_xml(tmp_path: Path) -> Path:
+    src = FIXTURES / 'partial_sell.ids.xml'
+    dst = tmp_path / 'roundtrip.xml'
+    shutil.copy(src, dst)
+    return dst
+
+
+def _build_portfolio(xml_path: Path):
+    """Parse an XML file through the full ppxml2db -> Portfolio pipeline."""
+    builder = PpPortfolioBuilder()
+    return builder.construct(xml_path)
+
+
+def _find_txn(portfolio, txn_type: str, date_str: str, security_uuid: str | None = None):
+    """Find a transaction in the portfolio by type and date.
+
+    Uses securities_account_transactions for security-related types,
+    deposit_account_transactions for cash-only types.
+    """
+    if security_uuid:
+        txns = portfolio.securities_account_transactions.reset_index()
+    else:
+        txns = portfolio.deposit_account_transactions.reset_index()
+
+    target_date = datetime.fromisoformat(date_str)
+    mask = (txns['type'] == txn_type) & (txns['date'].dt.date == target_date.date())
+    matched = txns[mask]
+
+    if len(matched) == 0:
+        return None
+    return matched.iloc[0]
+
+
+class TestRoundTripDeposit:
+
+    def test_deposit_appears_in_transactions(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_deposit(
+            'test-account-uuid-001',
+            datetime(2025, 6, 1),
+            5000.0,
+            'EUR',
+            note='Round-trip deposit',
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.DEPOSIT.value, '2025-06-01')
+        assert txn is not None
+        assert abs(txn['amount'] - 5000.0) < 0.01
+        assert txn['currency'] == 'EUR'
+
+
+class TestRoundTripWithdrawal:
+
+    def test_withdrawal_appears_in_transactions(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_withdrawal(
+            'test-account-uuid-001',
+            datetime(2025, 6, 15),
+            1200.0,
+            'EUR',
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.REMOVAL.value, '2025-06-15')
+        assert txn is not None
+        # Removal amounts are negative in the parsed DataFrame
+        assert abs(txn['amount'] - (-1200.0)) < 0.01
+
+
+class TestRoundTripBuy:
+
+    def test_buy_roundtrip(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_buy(
+            'test-security-uuid-001',
+            'test-account-uuid-001',
+            datetime(2025, 7, 1),
+            shares=15.0,
+            amount=750.0,
+            currency='EUR',
+            fees=9.95,
+            taxes=2.50,
+            note='Test buy',
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.BUY.value, '2025-07-01',
+                         security_uuid='test-security-uuid-001')
+        assert txn is not None
+        assert abs(txn['shares'] - 15.0) < 0.0001
+        assert abs(txn['fees'] - 9.95) < 0.01
+        assert abs(txn['taxes'] - 2.50) < 0.01
+        assert txn['currency'] == 'EUR'
+
+
+class TestRoundTripSell:
+
+    def test_sell_roundtrip(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_sell(
+            'test-security-uuid-001',
+            'test-account-uuid-001',
+            datetime(2025, 8, 1),
+            shares=3.0,
+            amount=180.0,
+            currency='EUR',
+            taxes=12.50,
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.SELL.value, '2025-08-01',
+                         security_uuid='test-security-uuid-001')
+        assert txn is not None
+        assert abs(txn['shares'] - 3.0) < 0.0001
+        assert abs(txn['taxes'] - 12.50) < 0.01
+
+
+class TestRoundTripDividend:
+
+    def test_dividend_roundtrip(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_dividend(
+            'test-security-uuid-001',
+            'test-account-uuid-001',
+            datetime(2025, 9, 15),
+            amount=42.50,
+            currency='EUR',
+            shares=10.0,
+            taxes=11.20,
+            note='Q3 dividend',
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.DIVIDENDS.value, '2025-09-15')
+        assert txn is not None
+        assert abs(txn['amount'] - 42.50) < 0.01
+        assert abs(txn['taxes'] - 11.20) < 0.01
+        assert abs(txn['shares'] - 10.0) < 0.0001
+
+
+class TestRoundTripInterest:
+
+    def test_interest_roundtrip(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_interest(
+            'test-account-uuid-001',
+            datetime(2025, 12, 31),
+            amount=25.75,
+            currency='EUR',
+            taxes=6.80,
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.INTEREST.value, '2025-12-31')
+        assert txn is not None
+        assert abs(txn['amount'] - 25.75) < 0.01
+        assert abs(txn['taxes'] - 6.80) < 0.01
+
+
+class TestRoundTripDelivery:
+
+    def test_delivery_inbound_roundtrip(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_delivery_inbound(
+            'test-security-uuid-001',
+            'test-portfolio-uuid-001',
+            datetime(2025, 10, 1),
+            shares=20.0,
+            amount=1000.0,
+            currency='EUR',
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.DELIVERY_INBOUND.value, '2025-10-01',
+                         security_uuid='test-security-uuid-001')
+        assert txn is not None
+        assert abs(txn['shares'] - 20.0) < 0.0001
+
+    def test_delivery_outbound_roundtrip(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_delivery_outbound(
+            'test-security-uuid-001',
+            'test-portfolio-uuid-001',
+            datetime(2025, 10, 15),
+            shares=5.0,
+            amount=300.0,
+            currency='EUR',
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.DELIVERY_OUTBOUND.value, '2025-10-15',
+                         security_uuid='test-security-uuid-001')
+        assert txn is not None
+        assert abs(txn['shares'] - 5.0) < 0.0001
+
+
+class TestRoundTripStockSplit:
+
+    def test_stock_split_roundtrip(self, writable_xml: Path) -> None:
+        """Stock splits are stored as security events, not transactions."""
+        from pp_terminal.data.ppxml2db_wrapper import Ppxml2dbWrapper, DB_NAME_IN_MEMORY
+
+        writer = PpXmlWriter(writable_xml)
+        writer.add_stock_split(
+            'test-security-uuid-001',
+            datetime(2025, 11, 1),
+            '4:1',
+            backup=False,
+        )
+
+        wrapper = Ppxml2dbWrapper(dbname=DB_NAME_IN_MEMORY)
+        wrapper.open(writable_xml)
+
+        cursor = wrapper.connection.cursor()
+        cursor.execute(
+            "SELECT type, details FROM security_event WHERE security = ?",
+            ('test-security-uuid-001',)
+        )
+        events = cursor.fetchall()
+        wrapper.close()
+
+        assert any(ev[0] == 'STOCK_SPLIT' and ev[1] == '4:1' for ev in events)
+
+
+class TestRoundTripAccountTransfer:
+
+    def test_transfer_roundtrip(self, writable_xml: Path) -> None:
+        """Account transfers need a second cash account.
+
+        The new account must appear *before* the existing one in the XML so
+        that ppxml2db's iterparse has already mapped its id when it encounters
+        the cross-entry ``accountTo reference``.
+        """
+        import lxml.etree as ET
+
+        tree = ET.parse(str(writable_xml))
+        root = tree.getroot()
+        accounts = root.find('accounts')
+        acc2 = ET.Element('account')
+        acc2.set('id', '100')
+        accounts.insert(0, acc2)  # before existing account
+        ET.SubElement(acc2, 'uuid').text = 'test-account-uuid-002'
+        ET.SubElement(acc2, 'name').text = 'Second Account'
+        ET.SubElement(acc2, 'currencyCode').text = 'EUR'
+        ET.SubElement(acc2, 'isRetired').text = 'false'
+        ET.SubElement(acc2, 'transactions')
+        attrs = ET.SubElement(acc2, 'attributes')
+        ET.SubElement(attrs, 'map')
+        ET.SubElement(acc2, 'updatedAt').text = '2025-01-01T00:00:00.000000Z'
+        tree.write(str(writable_xml), encoding='UTF-8', xml_declaration=True)
+
+        writer = PpXmlWriter(writable_xml)
+        writer.add_account_transfer(
+            'test-account-uuid-001',
+            'test-account-uuid-002',
+            datetime(2025, 12, 1),
+            2000.0,
+            'EUR',
+            note='Transfer test',
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        txn = _find_txn(portfolio, TransactionType.TRANSFER_OUT.value, '2025-12-01')
+        assert txn is not None
+        # TRANSFER_OUT amount is negative
+        assert abs(txn['amount'] - (-2000.0)) < 0.01
+
+
+class TestRoundTripSecurity:
+
+    def test_new_security_appears_after_roundtrip(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        sec_uuid = writer.add_security(
+            'Round-trip Test ETF',
+            'USD',
+            isin='US0000000001',
+            ticker='RT.US',
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+        secs = portfolio.securities
+        assert sec_uuid in secs.index
+        assert secs.loc[sec_uuid, 'name'] == 'Round-trip Test ETF'
+        assert secs.loc[sec_uuid, 'currency'] == 'USD'
+        assert secs.loc[sec_uuid, 'isin'] == 'US0000000001'
+
+
+class TestFullWorkflowRoundTrip:
+    """End-to-end: add a new security, deposit cash, buy shares, then verify
+    the complete portfolio state through the CLI."""
+
+    def test_full_workflow(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        new_sec_uuid = writer.add_security(
+            'New Corp Inc',
+            'EUR',
+            isin='DE9999999999',
+            backup=False,
+        )
+
+        writer2 = PpXmlWriter(writable_xml)
+        writer2.add_deposit(
+            'test-account-uuid-001',
+            datetime(2025, 1, 1),
+            100000.0,
+            'EUR',
+            backup=False,
+        )
+
+        writer3 = PpXmlWriter(writable_xml)
+        writer3.add_buy(
+            new_sec_uuid,
+            'test-account-uuid-001',
+            datetime(2025, 2, 1),
+            shares=50.0,
+            amount=5000.0,
+            currency='EUR',
+            fees=15.0,
+            backup=False,
+        )
+
+        portfolio = _build_portfolio(writable_xml)
+
+        # New security exists
+        assert new_sec_uuid in portfolio.securities.index
+        assert portfolio.securities.loc[new_sec_uuid, 'name'] == 'New Corp Inc'
+
+        # The buy transaction for the new security exists
+        txn = _find_txn(portfolio, TransactionType.BUY.value, '2025-02-01',
+                         security_uuid=new_sec_uuid)
+        assert txn is not None
+        assert abs(txn['shares'] - 50.0) < 0.0001
+        assert abs(txn['fees'] - 15.0) < 0.01
+
+    def test_cli_view_after_writes(self, writable_xml: Path) -> None:
+        """Verify the CLI can read back written data without errors."""
+        writer = PpXmlWriter(writable_xml)
+        writer.add_deposit(
+            'test-account-uuid-001',
+            datetime(2025, 5, 1),
+            3000.0,
+            'EUR',
+            backup=False,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(app, [
+            '--file', str(writable_xml),
+            '--output', 'json',
+            '--no-cache',
+            'view', 'accounts',
+        ])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        import json
+        data = json.loads(result.stdout)
+        assert len(data) >= 1
+
+        acc = next(a for a in data if a.get('name') == 'Test Cash Account')
+        assert acc is not None

--- a/tests/commands/test_roundtrip_import.py
+++ b/tests/commands/test_roundtrip_import.py
@@ -9,11 +9,13 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from typer.testing import CliRunner
 
 from pp_terminal.data.pp_portfolio_builder import PpPortfolioBuilder
 from pp_terminal.data.xml_writer import PpXmlWriter
+from pp_terminal.domain.portfolio import Portfolio
 from pp_terminal.domain.schemas import TransactionType
 from pp_terminal.main import app
 
@@ -28,13 +30,13 @@ def writable_xml(tmp_path: Path) -> Path:
     return dst
 
 
-def _build_portfolio(xml_path: Path):
+def _build_portfolio(xml_path: Path) -> Portfolio:
     """Parse an XML file through the full ppxml2db -> Portfolio pipeline."""
     builder = PpPortfolioBuilder()
     return builder.construct(xml_path)
 
 
-def _find_txn(portfolio, txn_type: str, date_str: str, security_uuid: str | None = None):
+def _find_txn(portfolio: Portfolio, txn_type: str, date_str: str, security_uuid: str | None = None) -> pd.Series | None:
     """Find a transaction in the portfolio by type and date.
 
     Uses securities_account_transactions for security-related types,

--- a/tests/commands/test_roundtrip_import.py
+++ b/tests/commands/test_roundtrip_import.py
@@ -3,6 +3,8 @@
 Verifies that every transaction type survives the full write -> parse -> query cycle.
 """
 
+# pylint: disable=redefined-outer-name,too-few-public-methods,import-outside-toplevel,duplicate-code
+
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -12,7 +14,7 @@ from typer.testing import CliRunner
 
 from pp_terminal.data.pp_portfolio_builder import PpPortfolioBuilder
 from pp_terminal.data.xml_writer import PpXmlWriter
-from pp_terminal.domain.schemas import TransactionType, AccountType
+from pp_terminal.domain.schemas import TransactionType
 from pp_terminal.main import app
 
 FIXTURES = Path(__file__).parent.parent / 'fixtures'
@@ -255,11 +257,10 @@ class TestRoundTripStockSplit:
 class TestRoundTripAccountTransfer:
 
     def test_transfer_roundtrip(self, writable_xml: Path) -> None:
-        """Account transfers need a second cash account.
-
-        The new account must appear *before* the existing one in the XML so
-        that ppxml2db's iterparse has already mapped its id when it encounters
-        the cross-entry ``accountTo reference``.
+        """Account transfers need the source account to appear before the
+        destination in the XML so that ppxml2db's iterparse has already
+        mapped the source id when it encounters the crossEntry's
+        ``accountFrom reference`` inside the destination's TRANSFER_IN.
         """
         import lxml.etree as ET
 
@@ -268,7 +269,7 @@ class TestRoundTripAccountTransfer:
         accounts = root.find('accounts')
         acc2 = ET.Element('account')
         acc2.set('id', '100')
-        accounts.insert(0, acc2)  # before existing account
+        accounts.append(acc2)  # after existing (source) account
         ET.SubElement(acc2, 'uuid').text = 'test-account-uuid-002'
         ET.SubElement(acc2, 'name').text = 'Second Account'
         ET.SubElement(acc2, 'currencyCode').text = 'EUR'

--- a/tests/data/test_xml_writer.py
+++ b/tests/data/test_xml_writer.py
@@ -1,0 +1,523 @@
+"""Tests for pp_terminal.data.xml_writer."""
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import lxml.etree as ET
+import pytest
+
+from pp_terminal.data.xml_writer import PpXmlWriter
+
+FIXTURES = Path(__file__).parent.parent / 'fixtures'
+
+
+@pytest.fixture
+def writable_xml(tmp_path: Path) -> Path:
+    """Copy partial_sell fixture to a temp dir for writing tests."""
+    src = FIXTURES / 'partial_sell.ids.xml'
+    dst = tmp_path / 'test_portfolio.xml'
+    shutil.copy(src, dst)
+    return dst
+
+
+def _parse(path: Path) -> ET.ElementTree:
+    return ET.parse(str(path))
+
+
+def _find_txn_by_uuid(root: ET.Element, uuid: str) -> ET.Element | None:
+    for el in root.iter():
+        uuid_el = el.find('uuid')
+        if uuid_el is not None and uuid_el.text == uuid:
+            return el
+    return None
+
+
+# ─── Security ───
+
+class TestAddSecurity:
+
+    def test_adds_security_element(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        sec_uuid = writer.add_security(
+            'Test ETF', 'EUR', isin='IE00TEST1234', wkn='TST01', ticker='TEST.DE',
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        root = tree.getroot()
+        securities = root.findall('.//securities/security')
+
+        # Should have original + new
+        new_sec = None
+        for sec in securities:
+            uuid_el = sec.find('uuid')
+            if uuid_el is not None and uuid_el.text == sec_uuid:
+                new_sec = sec
+                break
+
+        assert new_sec is not None
+        assert new_sec.find('name').text == 'Test ETF'
+        assert new_sec.find('currencyCode').text == 'EUR'
+        assert new_sec.find('isin').text == 'IE00TEST1234'
+        assert new_sec.find('wkn').text == 'TST01'
+        assert new_sec.find('tickerSymbol').text == 'TEST.DE'
+        assert new_sec.find('feed').text == 'MANUAL'
+        assert new_sec.find('isRetired').text == 'false'
+        assert new_sec.get('id') is not None
+
+    def test_security_has_unique_id(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_security('First', 'EUR', backup=False)
+        writer2 = PpXmlWriter(writable_xml)
+        writer2.add_security('Second', 'USD', backup=False)
+
+        tree = _parse(writable_xml)
+        ids = set()
+        for el in tree.getroot().iter():
+            id_val = el.get('id')
+            if id_val is not None:
+                assert id_val not in ids, f"Duplicate id={id_val}"
+                ids.add(id_val)
+
+
+# ─── Deposit / Withdrawal ───
+
+class TestSimpleAccountTransactions:
+
+    def test_add_deposit(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_deposit(
+            'test-account-uuid-001',
+            datetime(2025, 1, 15),
+            5000.0,
+            'EUR',
+            note='Salary',
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        txn = _find_txn_by_uuid(tree.getroot(), txn_uuid)
+        assert txn is not None
+        assert txn.tag == 'account-transaction'
+        assert txn.find('type').text == 'DEPOSIT'
+        assert txn.find('amount').text == '500000'  # 5000 * 100 cents
+        assert txn.find('currencyCode').text == 'EUR'
+        assert txn.find('note').text == 'Salary'
+        assert txn.find('shares').text == '0'
+
+    def test_add_withdrawal(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_withdrawal(
+            'test-account-uuid-001',
+            datetime(2025, 2, 1),
+            1000.0,
+            'EUR',
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        txn = _find_txn_by_uuid(tree.getroot(), txn_uuid)
+        assert txn is not None
+        assert txn.find('type').text == 'REMOVAL'
+        assert txn.find('amount').text == '100000'
+
+
+# ─── Buy / Sell ───
+
+class TestBuySell:
+
+    def test_add_buy_creates_cross_entry(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_buy(
+            'test-security-uuid-001',
+            'test-account-uuid-001',
+            datetime(2025, 3, 1),
+            shares=10.0,
+            amount=500.0,
+            currency='EUR',
+            fees=9.95,
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        root = tree.getroot()
+
+        # Find the portfolio transaction by UUID
+        port_txn = _find_txn_by_uuid(root, txn_uuid)
+        assert port_txn is not None
+        assert port_txn.find('type').text == 'BUY'
+        assert port_txn.find('shares').text == str(10 * 10**8)
+        assert port_txn.find('amount').text == '50000'
+
+        # Verify fee unit
+        fee_unit = port_txn.find('.//units/unit[@type="FEE"]/amount')
+        assert fee_unit is not None
+        assert fee_unit.get('amount') == '995'
+        assert fee_unit.get('currency') == 'EUR'
+
+        # Verify cross entry structure
+        cross = port_txn.find('crossEntry')
+        assert cross is not None
+        assert cross.get('class') == 'buysell'
+
+        # The cross entry should be a back-reference
+        assert cross.get('reference') is not None
+
+    def test_add_sell(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_sell(
+            'test-security-uuid-001',
+            'test-account-uuid-001',
+            datetime(2025, 4, 1),
+            shares=3.0,
+            amount=180.0,
+            currency='EUR',
+            taxes=5.25,
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        port_txn = _find_txn_by_uuid(tree.getroot(), txn_uuid)
+        assert port_txn is not None
+        assert port_txn.find('type').text == 'SELL'
+        assert port_txn.find('shares').text == str(3 * 10**8)
+
+        # Verify tax unit
+        tax_unit = port_txn.find('.//units/unit[@type="TAX"]/amount')
+        assert tax_unit is not None
+        assert tax_unit.get('amount') == '525'
+
+    def test_buy_adds_portfolio_reference(self, writable_xml: Path) -> None:
+        """Buy should add a portfolio-transaction reference in the portfolio's transactions."""
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_buy(
+            'test-security-uuid-001',
+            'test-account-uuid-001',
+            datetime(2025, 5, 1),
+            shares=5.0,
+            amount=250.0,
+            currency='EUR',
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        root = tree.getroot()
+
+        # Find the portfolio element (reference="11" in partial_sell fixture)
+        port_el = None
+        for p in root.findall('.//portfolios/portfolio'):
+            if p.get('reference') is not None:
+                # This is the reference element
+                port_el_ref = p
+                continue
+
+        # The portfolio's transactions should contain a reference to our new txn
+        port_txn = _find_txn_by_uuid(root, txn_uuid)
+        assert port_txn is not None
+
+        # Find the reference in portfolios/portfolio element
+        # The portfolio should have a portfolio-transaction ref pointing to our txn
+        port_found = False
+        for pt in root.iter('portfolio-transaction'):
+            ref = pt.get('reference')
+            if ref is not None and ref == port_txn.get('id'):
+                port_found = True
+                break
+        assert port_found, "Portfolio should contain a reference to the new portfolio-transaction"
+
+
+# ─── Dividend ───
+
+class TestDividend:
+
+    def test_add_dividend(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_dividend(
+            'test-security-uuid-001',
+            'test-account-uuid-001',
+            datetime(2025, 6, 15),
+            amount=42.50,
+            currency='EUR',
+            shares=10.0,
+            taxes=11.20,
+            note='Q2 dividend',
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        txn = _find_txn_by_uuid(tree.getroot(), txn_uuid)
+        assert txn is not None
+        assert txn.find('type').text == 'DIVIDENDS'
+        assert txn.find('amount').text == '4250'
+        assert txn.find('shares').text == str(10 * 10**8)
+        assert txn.find('note').text == 'Q2 dividend'
+
+        # Verify security reference
+        sec_ref = txn.find('security')
+        assert sec_ref is not None
+        assert sec_ref.get('reference') is not None
+
+        # Verify tax unit
+        tax_unit = txn.find('.//units/unit[@type="TAX"]/amount')
+        assert tax_unit is not None
+        assert tax_unit.get('amount') == '1120'
+
+
+# ─── Stock Split ───
+
+class TestStockSplit:
+
+    def test_add_stock_split(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_stock_split(
+            'test-security-uuid-001',
+            datetime(2025, 7, 1),
+            '4:1',
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        root = tree.getroot()
+
+        # Find the security
+        events = None
+        for sec in root.findall('.//securities/security'):
+            uuid_el = sec.find('uuid')
+            if uuid_el is not None and uuid_el.text == 'test-security-uuid-001':
+                events = sec.find('events')
+                break
+
+        assert events is not None
+        event_els = events.findall('event')
+        assert len(event_els) >= 1
+
+        split = event_els[-1]  # Last event should be our new split
+        assert split.find('type').text == 'STOCK_SPLIT'
+        assert split.find('details').text == '4:1'
+
+
+# ─── Delivery ───
+
+class TestDelivery:
+
+    def test_delivery_inbound(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_delivery_inbound(
+            'test-security-uuid-001',
+            'test-portfolio-uuid-001',
+            datetime(2025, 8, 1),
+            shares=20.0,
+            amount=1000.0,
+            currency='EUR',
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        txn = _find_txn_by_uuid(tree.getroot(), txn_uuid)
+        assert txn is not None
+        assert txn.tag == 'portfolio-transaction'
+        assert txn.find('type').text == 'DELIVERY_INBOUND'
+        assert txn.find('shares').text == str(20 * 10**8)
+        assert txn.find('amount').text == '100000'
+
+    def test_delivery_outbound(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_delivery_outbound(
+            'test-security-uuid-001',
+            'test-portfolio-uuid-001',
+            datetime(2025, 8, 15),
+            shares=5.0,
+            amount=300.0,
+            currency='EUR',
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        txn = _find_txn_by_uuid(tree.getroot(), txn_uuid)
+        assert txn is not None
+        assert txn.find('type').text == 'DELIVERY_OUTBOUND'
+
+
+# ─── Interest ───
+
+class TestInterest:
+
+    def test_add_interest(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        txn_uuid = writer.add_interest(
+            'test-account-uuid-001',
+            datetime(2025, 9, 30),
+            amount=12.75,
+            currency='EUR',
+            taxes=3.36,
+            backup=False,
+        )
+
+        tree = _parse(writable_xml)
+        txn = _find_txn_by_uuid(tree.getroot(), txn_uuid)
+        assert txn is not None
+        assert txn.find('type').text == 'INTEREST'
+        assert txn.find('amount').text == '1275'
+
+        # Verify tax unit
+        tax_unit = txn.find('.//units/unit[@type="TAX"]/amount')
+        assert tax_unit is not None
+        assert tax_unit.get('amount') == '336'
+
+
+# ─── Account Transfer ───
+
+class TestAccountTransfer:
+
+    def test_transfer_between_accounts(self, tmp_path: Path) -> None:
+        """Transfer needs two cash accounts — create a fixture with two."""
+        src = FIXTURES / 'partial_sell.ids.xml'
+        dst = tmp_path / 'two_accounts.xml'
+        shutil.copy(src, dst)
+
+        # Add a second account to the fixture
+        tree = ET.parse(str(dst))
+        root = tree.getroot()
+        accounts = root.find('accounts')
+        acc2 = ET.SubElement(accounts, 'account')
+        acc2.set('id', '100')
+        ET.SubElement(acc2, 'uuid').text = 'test-account-uuid-002'
+        ET.SubElement(acc2, 'name').text = 'Second Account'
+        ET.SubElement(acc2, 'currencyCode').text = 'EUR'
+        ET.SubElement(acc2, 'isRetired').text = 'false'
+        ET.SubElement(acc2, 'transactions')
+        attrs = ET.SubElement(acc2, 'attributes')
+        ET.SubElement(attrs, 'map')
+        ET.SubElement(acc2, 'updatedAt').text = '2025-01-01T00:00:00.000000Z'
+        tree.write(str(dst), encoding='UTF-8', xml_declaration=True)
+
+        writer = PpXmlWriter(dst)
+        txn_uuid = writer.add_account_transfer(
+            'test-account-uuid-001',
+            'test-account-uuid-002',
+            datetime(2025, 10, 1),
+            2000.0,
+            'EUR',
+            backup=False,
+        )
+
+        tree = _parse(dst)
+        root = tree.getroot()
+
+        # Find source transaction
+        txn = _find_txn_by_uuid(root, txn_uuid)
+        assert txn is not None
+        assert txn.find('type').text == 'TRANSFER_OUT'
+
+        # Verify cross entry
+        cross = txn.find('crossEntry')
+        assert cross is not None
+        assert cross.get('class') == 'account-transfer'
+
+        # Destination should have a reference
+        dest_txns = None
+        for acc in root.findall('accounts/account'):
+            uuid_el = acc.find('uuid')
+            if uuid_el is not None and uuid_el.text == 'test-account-uuid-002':
+                dest_txns = acc.find('transactions')
+                break
+
+        assert dest_txns is not None
+        refs = dest_txns.findall('account-transaction')
+        assert len(refs) >= 1
+
+
+# ─── Backup ───
+
+class TestBackup:
+
+    def test_backup_created_by_default(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_deposit(
+            'test-account-uuid-001',
+            datetime(2025, 1, 1),
+            100.0,
+            'EUR',
+            backup=True,
+        )
+
+        bak = writable_xml.with_suffix('.xml.bak')
+        assert bak.exists()
+
+    def test_no_backup_when_disabled(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        writer.add_deposit(
+            'test-account-uuid-001',
+            datetime(2025, 1, 1),
+            100.0,
+            'EUR',
+            backup=False,
+        )
+
+        bak = writable_xml.with_suffix('.xml.bak')
+        assert not bak.exists()
+
+
+# ─── Error handling ───
+
+class TestErrors:
+
+    def test_invalid_security_raises(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        with pytest.raises(Exception, match="not found"):
+            writer.add_buy(
+                'NONEXISTENT',
+                'test-account-uuid-001',
+                datetime(2025, 1, 1),
+                shares=1.0, amount=100.0, currency='EUR',
+                backup=False,
+            )
+
+    def test_invalid_account_raises(self, writable_xml: Path) -> None:
+        writer = PpXmlWriter(writable_xml)
+        with pytest.raises(Exception, match="not found"):
+            writer.add_deposit(
+                'nonexistent-account',
+                datetime(2025, 1, 1),
+                100.0, 'EUR',
+                backup=False,
+            )
+
+
+# ─── Roundtrip: write then import ───
+
+class TestRoundtrip:
+
+    def test_written_file_can_be_reimported(self, writable_xml: Path) -> None:
+        """Verify that after writing, ppxml2db can still parse the file."""
+        writer = PpXmlWriter(writable_xml)
+        writer.add_deposit(
+            'test-account-uuid-001',
+            datetime(2025, 1, 1),
+            100.0,
+            'EUR',
+            backup=False,
+        )
+        writer2 = PpXmlWriter(writable_xml)
+        writer2.add_buy(
+            'test-security-uuid-001',
+            'test-account-uuid-001',
+            datetime(2025, 2, 1),
+            shares=5.0,
+            amount=250.0,
+            currency='EUR',
+            backup=False,
+        )
+
+        # Verify lxml can still parse it
+        tree = _parse(writable_xml)
+        assert tree.getroot().tag == 'client'
+
+        # Verify all ids are unique
+        ids = []
+        for el in tree.getroot().iter():
+            id_val = el.get('id')
+            if id_val is not None:
+                ids.append(id_val)
+        assert len(ids) == len(set(ids)), "All id attributes must be unique"

--- a/tests/data/test_xml_writer.py
+++ b/tests/data/test_xml_writer.py
@@ -1,5 +1,7 @@
 """Tests for pp_terminal.data.xml_writer."""
 
+# pylint: disable=redefined-outer-name,too-few-public-methods,too-many-locals,too-many-statements,duplicate-code
+
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -161,8 +163,9 @@ class TestBuySell:
         assert cross is not None
         assert cross.get('class') == 'buysell'
 
-        # The cross entry should be a back-reference
-        assert cross.get('reference') is not None
+        # The crossEntry is either a canonical definition (id) or a back-reference
+        # (reference), depending on account/portfolio nesting in the fixture.
+        assert cross.get('reference') is not None or cross.get('id') is not None
 
     def test_add_sell(self, writable_xml: Path) -> None:
         writer = PpXmlWriter(writable_xml)
@@ -205,26 +208,38 @@ class TestBuySell:
         root = tree.getroot()
 
         # Find the portfolio element (reference="11" in partial_sell fixture)
-        port_el = None
         for p in root.findall('.//portfolios/portfolio'):
             if p.get('reference') is not None:
-                # This is the reference element
-                port_el_ref = p
                 continue
 
         # The portfolio's transactions should contain a reference to our new txn
         port_txn = _find_txn_by_uuid(root, txn_uuid)
         assert port_txn is not None
 
-        # Find the reference in portfolios/portfolio element
-        # The portfolio should have a portfolio-transaction ref pointing to our txn
-        port_found = False
+        # The canonical definition and the back-reference may live in either
+        # the portfolio's or the account's transactions, depending on nesting.
+        # Verify that the OTHER side has a matching back-reference.
+        port_txn_id = port_txn.get('id')
+        link_found = False
+        # Check for a portfolio-transaction reference to our txn
         for pt in root.iter('portfolio-transaction'):
             ref = pt.get('reference')
-            if ref is not None and ref == port_txn.get('id'):
-                port_found = True
+            if ref is not None and ref == port_txn_id:
+                link_found = True
                 break
-        assert port_found, "Portfolio should contain a reference to the new portfolio-transaction"
+        if not link_found:
+            # Pattern A: canonical PT is in portfolio, account side has
+            # an account-transaction reference to the nested accountTransaction
+            cross = port_txn.find('crossEntry')
+            if cross is not None:
+                at = cross.find('accountTransaction')
+                if at is not None:
+                    at_id = at.get('id')
+                    for el in root.iter('account-transaction'):
+                        if el.get('reference') == at_id:
+                            link_found = True
+                            break
+        assert link_found, "Should find a cross-linked reference for the new transaction"
 
 
 # ─── Dividend ───
@@ -405,17 +420,17 @@ class TestAccountTransfer:
         tree = _parse(dst)
         root = tree.getroot()
 
-        # Find source transaction
+        # Find source transaction by UUID — returned UUID is for TRANSFER_OUT
         txn = _find_txn_by_uuid(root, txn_uuid)
         assert txn is not None
         assert txn.find('type').text == 'TRANSFER_OUT'
 
-        # Verify cross entry
-        cross = txn.find('crossEntry')
-        assert cross is not None
-        assert cross.get('class') == 'account-transfer'
+        # Source transaction should have a crossEntry back-reference
+        cross_ref = txn.find('crossEntry')
+        assert cross_ref is not None
+        assert cross_ref.get('reference') is not None
 
-        # Destination should have a reference
+        # Destination account should have the canonical TRANSFER_IN
         dest_txns = None
         for acc in root.findall('accounts/account'):
             uuid_el = acc.find('uuid')
@@ -424,8 +439,37 @@ class TestAccountTransfer:
                 break
 
         assert dest_txns is not None
-        refs = dest_txns.findall('account-transaction')
-        assert len(refs) >= 1
+        # Find the canonical account-transaction (has an id, not a reference)
+        dest_canonical = [t for t in dest_txns.findall('account-transaction')
+                          if t.get('id') is not None and t.get('reference') is None]
+        assert len(dest_canonical) == 1
+        assert dest_canonical[0].find('type').text == 'TRANSFER_IN'
+
+        # The crossEntry inside should contain a canonical transactionFrom
+        cross = dest_canonical[0].find('crossEntry')
+        assert cross is not None
+        assert cross.get('class') == 'account-transfer'
+        from_txn = cross.find('transactionFrom')
+        assert from_txn is not None
+        assert from_txn.get('id') is not None  # canonical, not a reference
+        assert from_txn.find('type').text == 'TRANSFER_OUT'
+        # transactionFrom must have back-reference to parent crossEntry
+        inner_cross = from_txn.find('crossEntry')
+        assert inner_cross is not None
+        assert inner_cross.get('reference') == cross.get('id')
+
+        # Source account should have a reference to transactionFrom
+        src_txns = None
+        for acc in root.findall('accounts/account'):
+            uuid_el = acc.find('uuid')
+            if uuid_el is not None and uuid_el.text == 'test-account-uuid-001':
+                src_txns = acc.find('transactions')
+                break
+        assert src_txns is not None
+        src_refs = [t for t in src_txns.findall('account-transaction')
+                    if t.get('reference') is not None]
+        assert len(src_refs) == 1
+        assert src_refs[0].get('reference') == from_txn.get('id')
 
 
 # ─── Backup ───


### PR DESCRIPTION
## Summary

This PR adds write/import capabilities to pp-terminal, enabling programmatic creation of transactions, securities, and events in Portfolio Performance XML files — both via MCP tools and the CLI.

> [!NOTE] 
>This is a substantial feature addition that may be out of scope for the upstream project. I built this for my own use and am sharing it in case it is useful. No hard feelings if it is not accepted — I am happy to maintain it on my fork.

## Changes

### Commit 1: `fix: handle null property values in PP XML v69+` (PR #44)
- Fix crash when PP XML contains null property values (already merged separately)

### Commit 2: `feat: add import/write capabilities`
- **`PpXmlWriter`** — new module that writes transactions and securities into PP XML files via lxml, preserving existing structure and XStream id/reference semantics
- **Transaction types:** BUY, SELL, DIVIDEND, DEPOSIT, WITHDRAWAL, DELIVERY_INBOUND, DELIVERY_OUTBOUND, INTEREST, FEES, TAXES, ACCOUNT_TRANSFER, STOCK_SPLIT
- **Security definitions:** add new securities with ISIN, WKN, ticker, price feed
- **Delete:** remove transactions by UUID with cross-entry cleanup for transfers
- **11 MCP tools:** `import_security`, `import_buy`, `import_sell`, `import_dividend`, `import_deposit`, `import_withdrawal`, `import_delivery_inbound`, `import_delivery_outbound`, `import_interest`, `import_account_transfer`, `import_stock_split`, plus `import_fees`, `import_taxes`, `delete_transaction`
- **CLI `import` command group** with matching subcommands
- Automatic `.bak` backup before every write
- **18+ tests** covering all transaction types, backup behaviour, error handling, and full write-parse-query roundtrips

### Commit 3: `feat: add fees/taxes/delete tools, fix transfer structure`
- Fix `add_account_transfer` to produce PP-native XStream structure (canonical `TRANSFER_IN` in destination account, `transactionFrom` nested in crossEntry)
- Smart BUY/SELL crossEntry placement based on account/portfolio nesting to satisfy XStream document-order id/reference constraints
- Cross-currency transfer support (`to_amount`/`to_currency`)
- `portfolio_id` parameter for multi-currency BUY/SELL setups

## Testing

All 251 tests pass. The one pre-existing failure (`test_cache_fallback_on_io_error`) is unrelated to these changes.