### PR TITLE
Fix Depot Transfer Cost Basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,36 +140,6 @@ severity = "warning"
 tolerance = 0.01
 ```
 
-#### Built-in Validations
-
-The `negative-share-balance` security rule runs by default (severity `warning`, tolerance `0.001` shares) and flags securities
-whose share balance is negative in any securities account — an indicator of missing or inconsistent transactions, since short
-positions are not supported by Portfolio Performance. Configuring the rule yourself replaces the built-in default:
-
-```toml
-# Escalate to an error and adjust the tolerance (absolute share count)
-[[commands.validate.securities.rules]]
-type = "negative-share-balance"
-severity = "error"
-tolerance = 0.001
-
-# Or disable it entirely
-[[commands.validate.securities.rules]]
-type = "negative-share-balance"
-valid-months = []
-```
-
-The `unlinked-depot-transfer` security rule also runs by default (severity `warning`) and flags securities whose depot transfer
-(`TRANSFER_OUT`) has no linked destination account in Portfolio Performance's cross-entry data — a sign of corrupt or stale-cache
-data. The transferred shares' cost basis then stays attributed to the source account. Configure it the same way to escalate or
-disable it:
-
-```toml
-[[commands.validate.securities.rules]]
-type = "unlinked-depot-transfer"
-severity = "error"
-```
-
 #### Temporal Validation
 
 All validation rules optionally support temporal constraints through the `valid-months` configuration option. This allows rules to run only during specific months of the year:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ type = "negative-share-balance"
 valid-months = []
 ```
 
+The `unlinked-depot-transfer` security rule also runs by default (severity `warning`) and flags securities whose depot transfer
+(`TRANSFER_OUT`) has no linked destination account in Portfolio Performance's cross-entry data — a sign of corrupt or stale-cache
+data. The transferred shares' cost basis then stays attributed to the source account. Configure it the same way to escalate or
+disable it:
+
+```toml
+[[commands.validate.securities.rules]]
+type = "unlinked-depot-transfer"
+severity = "error"
+```
+
 #### Temporal Validation
 
 All validation rules optionally support temporal constraints through the `valid-months` configuration option. This allows rules to run only during specific months of the year:

--- a/pp_terminal/commands/simulate_share_sell.py
+++ b/pp_terminal/commands/simulate_share_sell.py
@@ -27,7 +27,7 @@ import pandas as pd
 import typer
 from pandera.typing import DataFrame
 
-from pp_terminal.data.filters import filter_by_account_and_security, filter_by_security, filter_by_account
+from pp_terminal.data.filters import filter_by_security, filter_by_account
 from pp_terminal.domain.cost_basis import enrich_fifo_lots, finalize_sell_lots
 from pp_terminal.data.tax import load_prepaid_tax_data
 from pp_terminal.domain.sell_strategy import SellStrategy, FixedSharesStrategy, MinTaxStrategy
@@ -71,24 +71,30 @@ def prepare_share_sell_df(  # pylint: disable=too-many-arguments,too-many-positi
 
     if security_id:
         holdings = holdings.pipe(filter_by_security, security_id=security_id)
-    if account_id:
-        holdings = holdings.pipe(filter_by_account, account_id=account_id)
 
     if holdings.empty:
         return pd.DataFrame()
 
-    security_ids = holdings.index.get_level_values('securityId').unique()
-    latest_prices = snapshot.latest_prices
+    all_transactions = snapshot.securities_account_transactions  # kept across all accounts so cost_basis can relocate transferred lots
 
+    security_ids = list(holdings.index.get_level_values('securityId').unique())
+    if account_id:
+        # a security's cost-basis lots can reside in an account that shows no net share balance there
+        # (e.g. the source account of an unlinked transfer), so scope by the securities transacted in
+        # the account rather than by its share balance to keep those lots sellable
+        account_security_ids = set(all_transactions.pipe(filter_by_account, account_id=account_id).index.get_level_values('securityId'))
+        security_ids = [sid for sid in security_ids if sid in account_security_ids]
+        if not security_ids:
+            return pd.DataFrame()
+
+    latest_prices = snapshot.latest_prices
     missing_prices = [sid for sid in security_ids if sid not in latest_prices.index]
     if missing_prices:
         raise InputError(f"No price data for: {', '.join(missing_prices)}")
 
     all_enriched = []
-    for (acc_id, sec_id, _currency), _shares_held in holdings.items():
-        transactions = snapshot.securities_account_transactions.pipe(
-            filter_by_account_and_security, security_id=sec_id, account_id=acc_id
-        )
+    for sec_id in security_ids:
+        transactions = all_transactions.pipe(filter_by_security, security_id=sec_id)
         sale_price = price if price else latest_prices.loc[sec_id]
         enriched = enrich_fifo_lots(
             transactions, snapshot.date, sale_price, tax_rate,
@@ -101,6 +107,12 @@ def prepare_share_sell_df(  # pylint: disable=too-many-arguments,too-many-positi
         return pd.DataFrame()
 
     result = pd.concat(all_enriched)
+
+    # enrichment spans all accounts to resolve transfers; keep only lots residing in the requested account
+    if account_id:
+        result = result.pipe(filter_by_account, account_id=account_id)
+        if result.empty:
+            return pd.DataFrame()
 
     strategy = _build_strategy(security_id, shares, target_net)
     if strategy:

--- a/pp_terminal/commands/simulate_share_sell.py
+++ b/pp_terminal/commands/simulate_share_sell.py
@@ -77,15 +77,13 @@ def prepare_share_sell_df(  # pylint: disable=too-many-arguments,too-many-positi
 
     all_transactions = snapshot.securities_account_transactions  # kept across all accounts so cost_basis can relocate transferred lots
 
-    security_ids = list(holdings.index.get_level_values('securityId').unique())
     if account_id:
-        # a security's cost-basis lots can reside in an account that shows no net share balance there
-        # (e.g. the source account of an unlinked transfer), so scope by the securities transacted in
-        # the account rather than by its share balance to keep those lots sellable
-        account_security_ids = set(all_transactions.pipe(filter_by_account, account_id=account_id).index.get_level_values('securityId'))
-        security_ids = [sid for sid in security_ids if sid in account_security_ids]
-        if not security_ids:
-            return pd.DataFrame()
+        # offer only securities with a positive net share balance in the requested account
+        # (snapshot.shares already drops zero/negative balances); the cross-account FIFO below still
+        # relocates linked-transfer lots, so a security transferred into the account stays sellable
+        holdings = holdings.pipe(filter_by_account, account_id=account_id)
+
+    security_ids = list(holdings.index.get_level_values('securityId').unique())
 
     latest_prices = snapshot.latest_prices
     missing_prices = [sid for sid in security_ids if sid not in latest_prices.index]

--- a/pp_terminal/config.schema.json
+++ b/pp_terminal/config.schema.json
@@ -224,10 +224,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["price-staleness", "price-limit", "price-limit-from-attribute", "cost-basis-limit", "cost-basis-limit-from-attribute", "paid-tax-validation", "negative-share-balance"]
+          "enum": ["price-staleness", "price-limit", "price-limit-from-attribute", "cost-basis-limit", "cost-basis-limit-from-attribute", "paid-tax-validation", "negative-share-balance", "unlinked-depot-transfer"]
         },
         "value": {
-          "description": "For price-staleness: an integer (days). For price-limit/cost-basis-limit: a number. For *-from-attribute rules: Portfolio Performance attribute UUID. For paid-tax-validation and negative-share-balance: not used (can be omitted).",
+          "description": "For price-staleness: an integer (days). For price-limit/cost-basis-limit: a number. For *-from-attribute rules: Portfolio Performance attribute UUID. For paid-tax-validation, negative-share-balance and unlinked-depot-transfer: not used (can be omitted).",
           "oneOf": [
             {
               "type": "number",

--- a/pp_terminal/data/pp_portfolio_builder.py
+++ b/pp_terminal/data/pp_portfolio_builder.py
@@ -116,9 +116,10 @@ class PpPortfolioBuilder:  # pylint: disable=too-few-public-methods
 
     def _parse_transactions(self) -> DataFrame[TransactionSchema]:
         transactions = (pd.read_sql_query("""
-select datetime(x.date) as date, ifnull(xu.forex_currency, x.currency) as currency, ifnull(xu.forex_amount, x.amount)-x.fees as amount_wo_fees, x.fees, x.taxes, x.uuid, x.account, x.type, x.security, x.shares, x.acctype
+select datetime(x.date) as date, ifnull(xu.forex_currency, x.currency) as currency, ifnull(xu.forex_amount, x.amount)-x.fees as amount_wo_fees, x.fees, x.taxes, x.uuid, x.account, x.type, x.security, x.shares, x.acctype, ce.to_acc as transferTargetAccount
 from xact as x
 left join xact_unit as xu on xu.xact = x.uuid and xu.type = 'GROSS_VALUE'
+left join xact_cross_entry as ce on ce.from_xact = x.uuid and ce.type = 'portfolio-transfer'
         """, self._db.connection, index_col=['date', 'account', 'security'], parse_dates={"date": "%Y-%m-%d %H:%M:%S"}, dtype={'amount_wo_fees': np.float64, 'shares': np.float64, 'taxes': np.float64})
                           .rename(columns={'amount_wo_fees': 'amount', 'acctype': 'accountType'}))
         transactions['shares'] = transactions['shares'] / _SCALE

--- a/pp_terminal/data/tax.py
+++ b/pp_terminal/data/tax.py
@@ -165,8 +165,10 @@ def calculate_prepaid_tax_per_lot(
     if lots.empty or tax_csv_data is None or tax_csv_data.empty:
         return pd.Series(0.0, index=lots.index)
 
-    # Add year columns to track original lot
+    # Track each lot by position: depot transfers can leave two lots sharing one
+    # (date, accountId, securityId) key, so that key is not a safe per-lot identity
     lots_with_years = lots.copy().reset_index()
+    lots_with_years['lotId'] = range(len(lots_with_years))
     lots_with_years['first_year'] = lots_with_years['date'].dt.year
     lots_with_years['last_year'] = current_date.year - 1
 
@@ -206,8 +208,9 @@ def calculate_prepaid_tax_per_lot(
         lot_years['shares'] * lot_years['deemed_income'] * lot_years['month_factor']
     )
 
-    # Group by original lot identity (MultiIndex columns) to sum deemed income across all years
-    per_lot_deemed_income = lot_years.groupby(['date', 'accountId', 'securityId'])['deemed_income_total'].sum()
+    # Group by the positional lot id (not the non-unique index key) to sum deemed income across all years
+    per_lot_deemed_income = lot_years.groupby('lotId')['deemed_income_total'].sum()
 
-    # Reindex to match original lots dataframe, filling missing with 0
-    return per_lot_deemed_income.reindex(lots.index, fill_value=0.0)
+    # Realign to the original lots positionally, filling lots without deemed income with 0
+    aligned = per_lot_deemed_income.reindex(range(len(lots)), fill_value=0.0)
+    return pd.Series(aligned.to_numpy(), index=lots.index)

--- a/pp_terminal/domain/cost_basis.py
+++ b/pp_terminal/domain/cost_basis.py
@@ -49,6 +49,7 @@ def _transfer_target_account(transfer_out_row: pd.Series) -> str | None:
 def _consume_lots_fifo(
         remaining_lots: list[dict[str, Any]],
         account_id: str,
+        security_id: str,
         shares_to_match: float,
         dest_account_id: str | None,
 ) -> tuple[float, list[dict[str, Any]]]:
@@ -56,7 +57,7 @@ def _consume_lots_fifo(
     for lot in remaining_lots:
         if shares_to_match <= 0:
             break
-        if lot['accountId'] != account_id:
+        if lot['accountId'] != account_id or lot['securityId'] != security_id:
             continue
         lot_shares = lot['shares']
         shares_from_lot = min(shares_to_match, lot_shares)
@@ -127,7 +128,7 @@ def _get_remaining_lots_after_fifo_matching(transactions: DataFrame[TransactionS
             log.warning('TRANSFER_OUT of %.4f shares of %s on %s has no linked destination account — keeping lots in the source account', shares_to_sell, security_id, txn_date)
             continue
 
-        unmatched, transferred_lots = _consume_lots_fifo(remaining_lots, account_id, shares_to_sell, dest_account_id)
+        unmatched, transferred_lots = _consume_lots_fifo(remaining_lots, account_id, security_id, shares_to_sell, dest_account_id)
         if transferred_lots:
             remaining_lots.extend(transferred_lots)
             # transferred lots keep their original purchase date, so restore acquisition-date

--- a/pp_terminal/domain/cost_basis.py
+++ b/pp_terminal/domain/cost_basis.py
@@ -19,6 +19,7 @@
 
 from datetime import datetime
 import logging
+from typing import Any
 
 import pandas as pd
 from pandera.typing import DataFrame
@@ -37,7 +38,45 @@ def _filter_purchase_transactions(transactions: DataFrame[TransactionSchema]) ->
     return TransactionSchema.validate(valid_purchases)
 
 
-def _get_remaining_lots_after_fifo_matching(transactions: DataFrame[TransactionSchema]) -> DataFrame[TaxLotSchema]:
+def _transfer_target_account(transfer_out_row: pd.Series) -> str | None:
+    """Destination securities account of a depot transfer, from Portfolio Performance's cross-entry link."""
+    target = transfer_out_row.get('transferTargetAccount')
+    if target is None or pd.isna(target) or str(target).strip() == '':
+        return None
+    return str(target)
+
+
+def _consume_lots_fifo(
+        remaining_lots: list[dict[str, Any]],
+        account_id: str,
+        shares_to_match: float,
+        dest_account_id: str | None,
+) -> tuple[float, list[dict[str, Any]]]:
+    transferred_lots: list[dict[str, Any]] = []
+    for lot in remaining_lots:
+        if shares_to_match <= 0:
+            break
+        if lot['accountId'] != account_id:
+            continue
+        lot_shares = lot['shares']
+        shares_from_lot = min(shares_to_match, lot_shares)
+        new_shares = lot_shares - shares_from_lot
+        shares_to_match -= shares_from_lot
+
+        if dest_account_id and lot_shares > 0:
+            ratio = shares_from_lot / lot_shares
+            # costBasis is left un-prorated here (still the source lot's full amount); every consumer
+            # recomputes it from purchasePrice * shares + fees before reading it (see _calculate_cost_basis)
+            transferred_lots.append({**lot, 'accountId': dest_account_id, 'shares': shares_from_lot, 'fees': lot['fees'] * ratio})
+
+        if lot_shares > 0:
+            lot['fees'] = lot['fees'] * (new_shares / lot_shares)
+        lot['shares'] = new_shares
+
+    return shares_to_match, transferred_lots
+
+
+def _get_remaining_lots_after_fifo_matching(transactions: DataFrame[TransactionSchema]) -> DataFrame[TaxLotSchema]:  # pylint: disable=too-many-locals
     """
     Match all sell transactions to purchase lots using FIFO and return remaining lots.
 
@@ -52,6 +91,12 @@ def _get_remaining_lots_after_fifo_matching(transactions: DataFrame[TransactionS
         for schema validation and interface consistency, internally we use list of dicts
         for ~10x faster mutation during the matching algorithm. DataFrame .loc[] access
         has significant overhead that doesn't add value for sequential state updates.
+
+        Depot transfers (TRANSFER_OUT → TRANSFER_IN pairs, as recorded by Portfolio
+        Performance's "Wertpapierübertrag" feature) are handled by moving FIFO lots from the
+        source account to the destination account while preserving the original acquisition
+        cost. The destination account is taken from the authoritative cross-entry link that
+        Portfolio Performance stores for each transfer (TransactionSchema.transferTargetAccount).
     """
     lots = _filter_purchase_transactions(transactions)
     lots['purchasePrice'] = lots['amount'].abs() / lots['shares']  # save actual market price per share
@@ -62,40 +107,36 @@ def _get_remaining_lots_after_fifo_matching(transactions: DataFrame[TransactionS
         return TaxLotSchema.validate(lots)
 
     sell_transactions = transactions.pipe(filter_by_type, transaction_types=[TransactionType.SELL, TransactionType.DELIVERY_OUTBOUND])
-    if sell_transactions.empty:
+    transfer_out_transactions = transactions.pipe(filter_by_type, transaction_types=[TransactionType.TRANSFER_OUT])
+
+    outgoing_frames = [f for f in [sell_transactions, transfer_out_transactions] if not f.empty]
+    if not outgoing_frames:
         return TaxLotSchema.validate(lots)
+    all_outgoing = pd.concat(outgoing_frames).sort_index(level='date')
 
-    # Convert to list of dicts for fast mutation during FIFO matching
     remaining_lots = lots.reset_index().to_dict('records')
-    sales_sorted = sell_transactions.sort_index(level='date')
 
-    for (_date, account_id, _security_id), row in sales_sorted.iterrows():
-        shares_to_match = float(row['shares'])
+    for (txn_date, account_id, security_id), row in all_outgoing.iterrows():
+        is_transfer_out = row['type'] == TransactionType.TRANSFER_OUT.name
+        shares_to_sell = float(row['shares'])
 
-        # Match against lots in FIFO order (only from same account)
-        for lot in remaining_lots:
-            if shares_to_match <= 0:
-                break
+        dest_account_id = _transfer_target_account(row) if is_transfer_out else None
+        if is_transfer_out and dest_account_id is None:
+            # no authoritative cross-entry link (corrupt or stale-cache data): keep the lots in the
+            # source account so security-level cost basis stays correct — only account attribution is stale
+            log.warning('TRANSFER_OUT of %.4f shares of %s on %s has no linked destination account — keeping lots in the source account', shares_to_sell, security_id, txn_date)
+            continue
 
-            if lot['accountId'] != account_id:
-                continue
+        unmatched, transferred_lots = _consume_lots_fifo(remaining_lots, account_id, shares_to_sell, dest_account_id)
+        if transferred_lots:
+            remaining_lots.extend(transferred_lots)
+            # transferred lots keep their original purchase date, so restore acquisition-date
+            # order for FIFO matching of subsequent sells in the destination account
+            remaining_lots.sort(key=lambda lot: lot['date'])
 
-            # Consume shares from this lot
-            lot_shares = lot['shares']
-            shares_from_lot = min(shares_to_match, lot_shares)
-            new_shares = lot_shares - shares_from_lot
-            shares_to_match -= shares_from_lot
+        if unmatched > 0.0001:  # Allow small floating point errors
+            log.warning('Sale/transfer of %.8f shares for security %s could not be fully matched to purchase lots', unmatched, security_id)
 
-            # Proportionally reduce fees based on remaining shares
-            if lot_shares > 0:
-                lot['fees'] = lot['fees'] * (new_shares / lot_shares)
-
-            lot['shares'] = new_shares
-
-        if shares_to_match > 0.0001:  # Allow small floating point errors
-            log.warning('Sale of %.8f shares for security %s could not be fully matched to purchase lots', shares_to_match, _security_id)
-
-    # Filter out exhausted lots and convert back to DataFrame
     remaining_lots = [lot for lot in remaining_lots if lot['shares'] > 0.0001]
     if not remaining_lots:
         return TaxLotSchema.empty()

--- a/pp_terminal/domain/schemas.py
+++ b/pp_terminal/domain/schemas.py
@@ -76,6 +76,7 @@ class TransactionSchema(pa.DataFrameModel):
     taxes: Series[Money] = pa.Field(default=0.0)
     fees: Optional[Series[Money]] = pa.Field(default=0.0, coerce=True)
     currency: Series[str] = pa.Field(nullable=True)
+    transferTargetAccount: Optional[Series[str]] = pa.Field(nullable=True)  # destination securities account of a TRANSFER_OUT (from PP's cross-entry link)
 
 
 class Account(BaseModel):  # pylint: disable=too-few-public-methods

--- a/pp_terminal/validation/rules.py
+++ b/pp_terminal/validation/rules.py
@@ -26,6 +26,7 @@ from pp_terminal.data.filters import filter_by_security
 from pp_terminal.domain.cost_basis import calculate_total_cost_basis
 from pp_terminal.domain.portfolio import Portfolio
 from pp_terminal.domain.portfolio_snapshot import PortfolioSnapshot
+from pp_terminal.domain.schemas import TransactionType
 from pp_terminal.validation.base import ValidationRule
 from pp_terminal.validation.vap_liquidity_rule import VapLiquidityRule
 from pp_terminal.validation.paid_tax_validation_rule import PaidTaxValidationRule
@@ -176,10 +177,50 @@ class NegativeShareBalanceRule(ValidationRule):
         return self.is_error(), message
 
 
+class UnlinkedDepotTransferRule(ValidationRule):
+    """Flags securities with a depot transfer (TRANSFER_OUT) that has no linked destination account.
+    Portfolio Performance records the destination via a cross-entry link; a missing link indicates
+    corrupt or stale-cache data, and the transferred shares' cost basis stays attributed to the
+    source account instead of the destination."""
+
+    @classmethod
+    def provide_context(cls, portfolio: Portfolio, snapshot: PortfolioSnapshot, config: dict[str, Any]) -> dict[str, Any]:
+        transactions = portfolio.securities_account_transactions
+        transfer_outs = transactions[transactions['type'] == TransactionType.TRANSFER_OUT.name]
+        if 'transferTargetAccount' not in transfer_outs.columns:
+            transfer_outs = transfer_outs.iloc[0:0]  # column absent: cannot assess (e.g. legacy/hand-built frames)
+        else:
+            target = transfer_outs['transferTargetAccount']
+            transfer_outs = transfer_outs[target.isna() | (target.fillna('').astype(str).str.strip() == '')]
+        return {
+            'unlinked_transfers': transfer_outs,
+            'account_names': portfolio.securities_accounts['name'],
+        }
+
+    def validate(self, entity: pd.Series, entity_id: str, context: dict[str, Any]) -> tuple[bool, str | None]:
+        is_error, message = super().validate(entity, entity_id, context)
+        if not self._should_apply():
+            return is_error, message
+
+        unlinked = context['unlinked_transfers']
+        security_transfers = unlinked[unlinked.index.get_level_values('securityId') == entity_id]
+        if security_transfers.empty:
+            return False, None
+
+        account_names = context['account_names']
+        details = ', '.join(
+            f'{shares:.2f} from "{account_names.get(account_id, account_id)}"'
+            for (_date, account_id, _sec), shares in security_transfers['shares'].items()
+        )
+        message = f'has a depot transfer with no linked destination account ({details}); cost basis stays with the source account (corrupt or stale-cache data)'
+        return self.is_error(), message
+
+
 def create_built_in_securities_rules() -> list[ValidationRule]:
     """Data-integrity rules that run by default; a user-configured rule of the same type replaces the built-in one."""
     return [
         NegativeShareBalanceRule(rule_type='negative-share-balance', value=None, severity='warning', tolerance=0.001),
+        UnlinkedDepotTransferRule(rule_type='unlinked-depot-transfer', value=None, severity='warning'),
     ]
 
 
@@ -195,6 +236,7 @@ _RULE_TYPES = {
     'vap-liquidity': VapLiquidityRule,
     'paid-tax-validation': PaidTaxValidationRule,
     'negative-share-balance': NegativeShareBalanceRule,
+    'unlinked-depot-transfer': UnlinkedDepotTransferRule,
 }
 
 

--- a/tests/data/test_pp_portfolio_builder.py
+++ b/tests/data/test_pp_portfolio_builder.py
@@ -21,11 +21,14 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 from _pytest.fixtures import TopRequest
 
 from pp_terminal.exceptions import InputError
 from pp_terminal.data.pp_portfolio_builder import PpPortfolioBuilder, CachedPpPortfolioBuilder
+from pp_terminal.data.ppxml2db_wrapper import Ppxml2dbWrapper, DB_NAME_IN_MEMORY
+from pp_terminal.domain.schemas import TransactionType
 from tests.conftest import EXEMPT_RATE_CONFIG
 
 
@@ -233,3 +236,35 @@ def test_securities_percent_attributes_converted(request: TopRequest) -> None:
     for value in securities_with_exemption[exempt_attr_uuid]:
         assert isinstance(value, float), f"Exemption rate should be float, got {type(value)}"
         assert 0.0 <= value <= 1.0, f"Exemption rate should be normalized (0.0-1.0), got {value}"
+
+
+def test_transfer_target_account_from_cross_entry(request: TopRequest) -> None:  # pylint: disable=unused-argument
+    """The portfolio-transfer cross-entry link must surface as transferTargetAccount on the TRANSFER_OUT row."""
+    db = Ppxml2dbWrapper(dbname=DB_NAME_IN_MEMORY)
+    conn = db.connection
+    conn.executescript("""
+        INSERT INTO account(_id, uuid, type, name, updatedAt, _xmlid, _order) VALUES
+            (1, 'depot1', 'portfolio', 'Depot 1', '2020', 1, 1),
+            (2, 'depot2', 'portfolio', 'Depot 2', '2020', 2, 2);
+        INSERT INTO security(_id, uuid, name, currency, updatedAt) VALUES
+            (1, 'sec1', 'Test ETF', 'EUR', '2020');
+        INSERT INTO xact(_id, uuid, acctype, account, date, currency, amount, security, shares, type, updatedAt, _xmlid, _order) VALUES
+            (1, 'x-buy', 'portfolio', 'depot1', '2020-01-15', 'EUR', 100000, 'sec1', 1000000000, 'BUY', '2020', 1, 1),
+            (2, 'x-out', 'portfolio', 'depot1', '2023-01-15', 'EUR', 0, 'sec1', 1000000000, 'TRANSFER_OUT', '2023', 2, 2),
+            (3, 'x-in', 'portfolio', 'depot2', '2023-01-15', 'EUR', 0, 'sec1', 1000000000, 'TRANSFER_IN', '2023', 3, 3);
+        INSERT INTO xact_cross_entry(type, from_acc, from_xact, to_acc, to_xact) VALUES
+            ('portfolio-transfer', 'depot1', 'x-out', 'depot2', 'x-in');
+    """)
+    conn.commit()
+
+    db.open = lambda _: None  # type: ignore  # DB already seeded, skip XML parsing
+    portfolio = PpPortfolioBuilder(db).construct(Path('unused.xml'))
+
+    transactions = portfolio.securities_account_transactions.reset_index()
+    transfer_out = transactions[transactions['type'] == TransactionType.TRANSFER_OUT.value]
+    assert len(transfer_out) == 1
+    assert transfer_out.iloc[0]['transferTargetAccount'] == 'depot2'
+
+    # non-transfer rows carry no destination link
+    buy = transactions[transactions['type'] == TransactionType.BUY.value]
+    assert pd.isna(buy.iloc[0]['transferTargetAccount'])

--- a/tests/domain/test_depot_transfer.py
+++ b/tests/domain/test_depot_transfer.py
@@ -38,26 +38,31 @@ SELL_DATE = datetime(2024, 12, 31)
 _TRANSACTION_COLUMNS = ['date', 'accountId', 'securityId', 'type', 'amount', 'shares', 'accountType', 'currency', 'taxes', 'fees', 'transferTargetAccount']
 
 
-def build_portfolio(transaction_rows: list[list[object]]) -> Portfolio:
-    """Two-depot portfolio around a single security for depot transfer scenarios."""
+def build_portfolio(
+    transaction_rows: list[list[object]],
+    securities: pd.DataFrame | None = None,
+    prices: pd.DataFrame | None = None,
+) -> Portfolio:
+    """Two-depot portfolio for depot transfer scenarios (defaults to a single priced security 'sec1')."""
     accounts = pd.DataFrame([
         ['Depot 1', AccountType.SECURITIES.value, None, False, 'EUR'],
         ['Depot 2', AccountType.SECURITIES.value, None, False, 'EUR'],
     ], columns=['name', 'type', 'referenceAccount', 'isRetired', 'currency'], index=['depot1', 'depot2'])
     accounts.index.name = 'accountId'
 
-    securities = pd.DataFrame([
-        ['Test ETF', 'IE00B4L5Y983', 'EUR'],
-    ], columns=['name', 'wkn', 'currency'], index=['sec1'])
-    securities.index.name = 'securityId'
+    if securities is None:
+        securities = pd.DataFrame([
+            ['Test ETF', 'IE00B4L5Y983', 'EUR'],
+        ], columns=['name', 'wkn', 'currency'], index=['sec1'])
+        securities.index.name = 'securityId'
+
+    if prices is None:
+        prices = pd.DataFrame([
+            [SELL_DATE, 'sec1', 160.0],
+        ], columns=['date', 'securityId', 'price']).set_index(['date', 'securityId'])
 
     transactions = pd.DataFrame(transaction_rows, columns=_TRANSACTION_COLUMNS)
     transactions = transactions.set_index(['date', 'accountId', 'securityId'])
-
-    prices = pd.DataFrame([
-        [SELL_DATE, 'sec1', 160.0],
-    ], columns=['date', 'securityId', 'price'])
-    prices = prices.set_index(['date', 'securityId'])
 
     portfolio = Portfolio(accounts, transactions, securities, prices)
     portfolio.base_currency = 'EUR'
@@ -158,6 +163,30 @@ def test_sell_in_source_account_after_transfer() -> None:
     assert lots.loc['depot1', 'shares'] == pytest.approx(5.0)
 
 
+def test_fifo_matching_is_scoped_per_security_within_an_account() -> None:
+    """A sell (or transfer) must consume only lots of its own security: another security's older lot in
+    the same account must never be matched against it."""
+    securities = pd.DataFrame(
+        [['ETF One', 'IE00B4L5Y983', 'EUR'], ['ETF Two', 'IE00B4L5YC18', 'EUR']],
+        columns=['name', 'wkn', 'currency'], index=['sec1', 'sec2'])
+    securities.index.name = 'securityId'
+    prices = pd.DataFrame(
+        [[SELL_DATE, 'sec1', 160.0], [SELL_DATE, 'sec2', 600.0]],
+        columns=['date', 'securityId', 'price']).set_index(['date', 'securityId'])
+
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2022, 1, 15), 'depot1', 'sec2', TransactionType.BUY.value, -5000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2024, 1, 10), 'depot1', 'sec2', TransactionType.SELL.value, 6000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ], securities=securities, prices=prices)
+
+    lots = remaining_lots(portfolio)
+    # the sec2 sell consumes sec2's own lot; sec1's older 100-lot stays untouched
+    assert set(lots['securityId']) == {'sec1'}
+    assert lots['shares'].sum() == pytest.approx(10.0)
+    assert lots.iloc[0]['purchasePrice'] == pytest.approx(100.0)
+
+
 def test_same_day_transfers_between_distinct_pairs_do_not_collide() -> None:
     """Two same-day, equal-size transfers of the same security route to their own destinations (no key collision)."""
     portfolio = build_portfolio([
@@ -224,8 +253,8 @@ def test_share_sell_account_filter_includes_transferred_lots() -> None:
     assert result['purchasePrice'].iloc[0] == pytest.approx(100.0)
 
 
-# Regression tests for /code-review findings #1 and #3 (fixed here) and #4 (a post-refactor
-# behaviour change pinned as a characterization test so any future change to it is deliberate).
+# Regression tests for depot-transfer cost-basis edge cases, including a characterization test that
+# pins a deliberate post-refactor behaviour change so any future change to it stays intentional.
 
 
 def _deemed_income_data(year: int, security_id: str, per_share: float) -> pd.DataFrame:
@@ -237,9 +266,9 @@ def _deemed_income_data(year: int, security_id: str, per_share: float) -> pd.Dat
 
 
 def test_transfer_merging_same_date_lot_does_not_double_count_deemed_income() -> None:
-    """Finding #1: a transfer into an account already holding a same-date lot of the same security
-    yields two lots sharing one (date, accountId, securityId) key; deemed income must be attributed
-    per lot, not summed across the shared key and broadcast back onto both."""
+    """A transfer into an account already holding a same-date lot of the same security yields two lots
+    sharing one (date, accountId, securityId) key; deemed income must be attributed per lot, not summed
+    across the shared key and broadcast back onto both."""
     portfolio = build_portfolio([
         [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
         [datetime(2020, 1, 15), 'depot2', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
@@ -254,27 +283,10 @@ def test_transfer_merging_same_date_lot_does_not_double_count_deemed_income() ->
     assert lots['deemedIncome'].sum() == pytest.approx(20.0)
 
 
-def test_share_sell_offers_unlinked_transfer_lots_from_source_account() -> None:
-    """Finding #3: an unlinked TRANSFER_OUT keeps the cost basis in the source account, so the shares
-    must stay sellable from there even though that account shows no net share balance after the
-    transfer. They are not offered from the destination, since no cost basis was relocated to it."""
-    portfolio = build_portfolio([
-        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
-        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
-        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
-    ])
-
-    from_source = prepare_share_sell_df(portfolio, {}, SELL_DATE, TAX_RATE, account_id='depot1')
-    assert from_source['shares'].sum() == pytest.approx(10.0)
-    assert from_source['purchasePrice'].iloc[0] == pytest.approx(100.0)
-
-    assert prepare_share_sell_df(portfolio, {}, SELL_DATE, TAX_RATE, account_id='depot2').empty
-
-
 def test_fixed_shares_selects_globally_oldest_lot_across_accounts() -> None:
-    """Characterization (finding #4): after the refactor, --shares without --account-id selects lots in
-    global acquisition-date order across accounts, not grouped by account as before. Pins the behaviour so
-    a future change is deliberate rather than silent."""
+    """Characterization test: --shares without --account-id selects lots in global acquisition-date order
+    across accounts, not grouped by account as before. Pins the behaviour so a future change is deliberate
+    rather than silent."""
     portfolio = build_portfolio([
         [datetime(2022, 6, 1), 'depot1', 'sec1', TransactionType.BUY.value, -1400.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
         [datetime(2020, 1, 15), 'depot2', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
@@ -284,3 +296,28 @@ def test_fixed_shares_selects_globally_oldest_lot_across_accounts() -> None:
 
     assert result.iloc[0]['date'] == datetime(2020, 1, 15)          # depot2's older lot, not depot1's
     assert result.iloc[0]['purchasePrice'] == pytest.approx(100.0)
+
+
+def test_share_sell_account_filter_ignores_missing_price_of_security_transferred_out() -> None:
+    """A security fully transferred out of the requested account has no sellable lots there, so its absent
+    price must not abort the simulation of another security still held in that account."""
+    securities = pd.DataFrame(
+        [['Transferred ETF', 'IE00B4L5Y983', 'EUR'], ['Held ETF', 'IE00B4L5YC18', 'EUR']],
+        columns=['name', 'wkn', 'currency'], index=['sec1', 'sec2'])
+    securities.index.name = 'securityId'
+
+    prices = pd.DataFrame([[SELL_DATE, 'sec2', 200.0]],  # sec1 deliberately has no price
+                          columns=['date', 'securityId', 'price']).set_index(['date', 'securityId'])
+
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot2'],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2021, 3, 1), 'depot1', 'sec2', TransactionType.BUY.value, -1500.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ], securities=securities, prices=prices)
+
+    result = prepare_share_sell_df(portfolio, {}, SELL_DATE, TAX_RATE, account_id='depot1')
+
+    # only sec2 (held & priced in depot1) is offered; sec1's missing price no longer raises InputError
+    assert set(result['securityName']) == {'Held ETF'}
+    assert result['shares'].sum() == pytest.approx(10.0)

--- a/tests/domain/test_depot_transfer.py
+++ b/tests/domain/test_depot_transfer.py
@@ -1,0 +1,286 @@
+"""
+    Copyright (C) 2025-26 Dipl.-Ing. Christoph Massmann <chris@dev-investor.de>
+
+    This file is part of pp-terminal.
+
+    pp-terminal is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    pp-terminal is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with pp-terminal. If not, see <http://www.gnu.org/licenses/>.
+"""
+# pylint: disable=duplicate-code
+
+import logging
+from datetime import datetime
+
+import pandas as pd
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from pp_terminal.commands.simulate_share_sell import prepare_share_sell_df
+from pp_terminal.domain.cost_basis import calculate_total_cost_basis, enrich_fifo_lots
+from pp_terminal.domain.portfolio import Portfolio
+from pp_terminal.domain.schemas import AccountType, TransactionType, TaxPaidSchema
+
+TAX_RATE = 26.375
+SELL_DATE = datetime(2024, 12, 31)
+
+# transferTargetAccount carries Portfolio Performance's authoritative cross-entry link: the destination
+# securities account of a TRANSFER_OUT. It is None for every other transaction type.
+_TRANSACTION_COLUMNS = ['date', 'accountId', 'securityId', 'type', 'amount', 'shares', 'accountType', 'currency', 'taxes', 'fees', 'transferTargetAccount']
+
+
+def build_portfolio(transaction_rows: list[list[object]]) -> Portfolio:
+    """Two-depot portfolio around a single security for depot transfer scenarios."""
+    accounts = pd.DataFrame([
+        ['Depot 1', AccountType.SECURITIES.value, None, False, 'EUR'],
+        ['Depot 2', AccountType.SECURITIES.value, None, False, 'EUR'],
+    ], columns=['name', 'type', 'referenceAccount', 'isRetired', 'currency'], index=['depot1', 'depot2'])
+    accounts.index.name = 'accountId'
+
+    securities = pd.DataFrame([
+        ['Test ETF', 'IE00B4L5Y983', 'EUR'],
+    ], columns=['name', 'wkn', 'currency'], index=['sec1'])
+    securities.index.name = 'securityId'
+
+    transactions = pd.DataFrame(transaction_rows, columns=_TRANSACTION_COLUMNS)
+    transactions = transactions.set_index(['date', 'accountId', 'securityId'])
+
+    prices = pd.DataFrame([
+        [SELL_DATE, 'sec1', 160.0],
+    ], columns=['date', 'securityId', 'price'])
+    prices = prices.set_index(['date', 'securityId'])
+
+    portfolio = Portfolio(accounts, transactions, securities, prices)
+    portfolio.base_currency = 'EUR'
+    return portfolio
+
+
+def remaining_lots(portfolio: Portfolio) -> pd.DataFrame:
+    lots = enrich_fifo_lots(portfolio.securities_account_transactions, SELL_DATE, sell_price=160.0, tax_rate=TAX_RATE)
+    return lots.reset_index().sort_values(['date', 'accountId'])
+
+
+def test_full_transfer_preserves_cost_basis() -> None:
+    """A depot transfer must move the lot to the destination account with unchanged acquisition data."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 10.0, None],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot2'],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    assert calculate_total_cost_basis(portfolio.securities_account_transactions) == pytest.approx(1010.0)  # 10 x 100 + 10 fees
+
+    lots = remaining_lots(portfolio)
+    assert len(lots) == 1
+    assert lots.iloc[0]['accountId'] == 'depot2'
+    assert lots.iloc[0]['date'] == datetime(2020, 1, 15)  # original acquisition date preserved
+    assert lots.iloc[0]['shares'] == pytest.approx(10.0)
+    assert lots.iloc[0]['purchasePrice'] == pytest.approx(100.0)
+    assert lots.iloc[0]['fees'] == pytest.approx(10.0)
+
+
+def test_transfer_pairs_via_cross_entry_regardless_of_leg_dates() -> None:
+    """Pairing uses the authoritative cross-entry link, so transfer legs booked on different days still pair."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2022, 12, 30), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot2'],
+        [datetime(2023, 1, 2), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    assert calculate_total_cost_basis(portfolio.securities_account_transactions) == pytest.approx(1000.0)
+
+    lots = remaining_lots(portfolio)
+    assert len(lots) == 1
+    assert lots.iloc[0]['accountId'] == 'depot2'
+    assert lots.iloc[0]['purchasePrice'] == pytest.approx(100.0)
+
+
+def test_partial_transfer_splits_lot_and_prorates_fees() -> None:
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 10.0, None],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 4.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot2'],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 4.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    lots = remaining_lots(portfolio).set_index('accountId')
+    assert len(lots) == 2
+    assert lots.loc['depot1', 'shares'] == pytest.approx(6.0)
+    assert lots.loc['depot1', 'fees'] == pytest.approx(6.0)
+    assert lots.loc['depot2', 'shares'] == pytest.approx(4.0)
+    assert lots.loc['depot2', 'fees'] == pytest.approx(4.0)
+    assert lots.loc['depot1', 'purchasePrice'] == pytest.approx(100.0)
+    assert lots.loc['depot2', 'purchasePrice'] == pytest.approx(100.0)
+
+    assert calculate_total_cost_basis(portfolio.securities_account_transactions) == pytest.approx(1010.0)
+
+
+def test_sell_after_transfer_consumes_transferred_lot_first() -> None:
+    """FIFO in the destination depot must consume by original acquisition date, not by lot arrival order."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot2'],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 5, 1), 'depot2', 'sec1', TransactionType.BUY.value, -2000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2024, 1, 10), 'depot2', 'sec1', TransactionType.SELL.value, 2500.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    lots = remaining_lots(portfolio)
+    assert len(lots) == 1
+    assert lots.iloc[0]['date'] == datetime(2023, 5, 1)  # the transferred 2020 lot was consumed first
+    assert lots.iloc[0]['purchasePrice'] == pytest.approx(200.0)
+    assert lots.iloc[0]['shares'] == pytest.approx(10.0)
+
+
+def test_sell_in_source_account_after_transfer() -> None:
+    """After the oldest lot moved away, sells in the source account consume its remaining lots."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2021, 3, 1), 'depot1', 'sec1', TransactionType.BUY.value, -1400.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot2'],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2024, 1, 10), 'depot1', 'sec1', TransactionType.SELL.value, 800.0, 5.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    lots = remaining_lots(portfolio).set_index('accountId')
+    assert len(lots) == 2
+    assert lots.loc['depot2', 'purchasePrice'] == pytest.approx(100.0)  # transferred 2020 lot untouched
+    assert lots.loc['depot2', 'shares'] == pytest.approx(10.0)
+    assert lots.loc['depot1', 'purchasePrice'] == pytest.approx(140.0)
+    assert lots.loc['depot1', 'shares'] == pytest.approx(5.0)
+
+
+def test_same_day_transfers_between_distinct_pairs_do_not_collide() -> None:
+    """Two same-day, equal-size transfers of the same security route to their own destinations (no key collision)."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2020, 6, 1), 'depot2', 'sec1', TransactionType.BUY.value, -1500.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot2'],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot1'],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    lots = remaining_lots(portfolio)
+    # the heuristic keyed transfers on (date, security, shares), so these two collided and both
+    # resolved to the same destination; the cross-entry link routes each to its own depot instead.
+    # (Which depot ends with which lot on a same-day swap depends on processing order — a separate concern.)
+    assert set(lots['accountId']) == {'depot1', 'depot2'}  # both depots still hold a lot, neither emptied
+    assert sorted(lots['purchasePrice']) == pytest.approx([100.0, 150.0])  # both acquisition costs preserved
+
+
+@pytest.mark.parametrize('target', [None, ''])
+def test_transfer_out_without_cross_entry_link_keeps_lots_in_source(target: str | None, caplog: LogCaptureFixture) -> None:
+    """A TRANSFER_OUT with no linked destination (corrupt or stale-cache data) keeps the lots in the source account."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, target],
+    ])
+
+    with caplog.at_level(logging.WARNING):
+        cost_basis = calculate_total_cost_basis(portfolio.securities_account_transactions)
+
+    assert cost_basis == pytest.approx(1000.0)  # lot preserved, only account attribution is stale
+    assert 'keeping lots in the source account' in caplog.text
+
+    lots = remaining_lots(portfolio)
+    assert len(lots) == 1
+    assert lots.iloc[0]['accountId'] == 'depot1'
+    assert lots.iloc[0]['shares'] == pytest.approx(10.0)
+
+
+def test_share_sell_account_filter_excludes_other_accounts() -> None:
+    """simulate share-sell --account-id must not offer lots residing in other accounts."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2021, 3, 1), 'depot2', 'sec1', TransactionType.BUY.value, -700.0, 5.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    result = prepare_share_sell_df(portfolio, {}, SELL_DATE, TAX_RATE, account_id='depot1')
+
+    assert result['shares'].sum() == pytest.approx(10.0)
+    assert result['purchasePrice'].iloc[0] == pytest.approx(100.0)
+
+
+def test_share_sell_account_filter_includes_transferred_lots() -> None:
+    """Lots transferred into the requested account belong to it, with cost basis intact."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot2', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot1'],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    result = prepare_share_sell_df(portfolio, {}, SELL_DATE, TAX_RATE, account_id='depot1')
+
+    assert result['shares'].sum() == pytest.approx(10.0)
+    assert result['purchasePrice'].iloc[0] == pytest.approx(100.0)
+
+
+# Regression tests for /code-review findings #1 and #3 (fixed here) and #4 (a post-refactor
+# behaviour change pinned as a characterization test so any future change to it is deliberate).
+
+
+def _deemed_income_data(year: int, security_id: str, per_share: float) -> pd.DataFrame:
+    """A one-row prepaid-tax (Vorabpauschale) table, as load_prepaid_tax_data would produce."""
+    return TaxPaidSchema.validate(pd.DataFrame(
+        {'deemed_income': [per_share]},
+        index=pd.MultiIndex.from_arrays([[year], [security_id]], names=['year', 'security_id']),
+    ))
+
+
+def test_transfer_merging_same_date_lot_does_not_double_count_deemed_income() -> None:
+    """Finding #1: a transfer into an account already holding a same-date lot of the same security
+    yields two lots sharing one (date, accountId, securityId) key; deemed income must be attributed
+    per lot, not summed across the shared key and broadcast back onto both."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2020, 1, 15), 'depot2', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot1'],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+    tax_data = _deemed_income_data(2021, 'sec1', 1.0)
+
+    lots = enrich_fifo_lots(portfolio.securities_account_transactions, SELL_DATE, sell_price=160.0, tax_rate=TAX_RATE, tax_csv_data=tax_data)
+
+    # 20 held shares x 1.0/share deemed income for 2021 = 20.0; the bug reports 40.0.
+    assert lots['deemedIncome'].sum() == pytest.approx(20.0)
+
+
+def test_share_sell_offers_unlinked_transfer_lots_from_source_account() -> None:
+    """Finding #3: an unlinked TRANSFER_OUT keeps the cost basis in the source account, so the shares
+    must stay sellable from there even though that account shows no net share balance after the
+    transfer. They are not offered from the destination, since no cost basis was relocated to it."""
+    portfolio = build_portfolio([
+        [datetime(2020, 1, 15), 'depot1', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot1', 'sec1', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2023, 1, 15), 'depot2', 'sec1', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    from_source = prepare_share_sell_df(portfolio, {}, SELL_DATE, TAX_RATE, account_id='depot1')
+    assert from_source['shares'].sum() == pytest.approx(10.0)
+    assert from_source['purchasePrice'].iloc[0] == pytest.approx(100.0)
+
+    assert prepare_share_sell_df(portfolio, {}, SELL_DATE, TAX_RATE, account_id='depot2').empty
+
+
+def test_fixed_shares_selects_globally_oldest_lot_across_accounts() -> None:
+    """Characterization (finding #4): after the refactor, --shares without --account-id selects lots in
+    global acquisition-date order across accounts, not grouped by account as before. Pins the behaviour so
+    a future change is deliberate rather than silent."""
+    portfolio = build_portfolio([
+        [datetime(2022, 6, 1), 'depot1', 'sec1', TransactionType.BUY.value, -1400.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2020, 1, 15), 'depot2', 'sec1', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ])
+
+    result = prepare_share_sell_df(portfolio, {}, SELL_DATE, TAX_RATE, security_id='sec1', shares=5.0)
+
+    assert result.iloc[0]['date'] == datetime(2020, 1, 15)          # depot2's older lot, not depot1's
+    assert result.iloc[0]['purchasePrice'] == pytest.approx(100.0)

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -193,8 +193,8 @@ def test_should_merge_fragments_deterministically_regardless_of_registration_ord
 
 
 def test_should_accept_reconfiguring_the_unlinked_depot_transfer_builtin_rule(tmp_path: Path) -> None:
-    """Finding #2: the built-in 'unlinked-depot-transfer' security rule must be a valid config type
-    so users can reconfigure or disable it like the sibling built-in 'negative-share-balance'."""
+    """The built-in 'unlinked-depot-transfer' security rule must be a valid config type so users can
+    reconfigure or disable it like the sibling built-in 'negative-share-balance'."""
     config = '[[commands.validate.securities.rules]]\ntype = "unlinked-depot-transfer"\nseverity = "error"\n'
 
     result = validated_toml_loader(_write_config(tmp_path, config))

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -190,3 +190,14 @@ def test_should_merge_fragments_deterministically_regardless_of_registration_ord
     second = json.dumps(_merged_schema())
 
     assert first == second
+
+
+def test_should_accept_reconfiguring_the_unlinked_depot_transfer_builtin_rule(tmp_path: Path) -> None:
+    """Finding #2: the built-in 'unlinked-depot-transfer' security rule must be a valid config type
+    so users can reconfigure or disable it like the sibling built-in 'negative-share-balance'."""
+    config = '[[commands.validate.securities.rules]]\ntype = "unlinked-depot-transfer"\nseverity = "error"\n'
+
+    result = validated_toml_loader(_write_config(tmp_path, config))
+
+    rules = get_command_config(result, 'validate.securities.rules')
+    assert rules[0]['type'] == 'unlinked-depot-transfer'

--- a/tests/validation/test_unlinked_depot_transfer.py
+++ b/tests/validation/test_unlinked_depot_transfer.py
@@ -1,0 +1,94 @@
+"""
+    Copyright (C) 2025-26 Dipl.-Ing. Christoph Massmann <chris@dev-investor.de>
+
+    This file is part of pp-terminal.
+
+    pp-terminal is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    pp-terminal is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with pp-terminal. If not, see <http://www.gnu.org/licenses/>.
+"""
+# pylint: disable=duplicate-code
+
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+from pp_terminal.domain.portfolio import Portfolio
+from pp_terminal.domain.portfolio_snapshot import PortfolioSnapshot
+from pp_terminal.domain.schemas import AccountType, TransactionType
+from pp_terminal.validation.engine import validate_securities, ValidationResult
+
+_COLUMNS = ['date', 'accountId', 'securityId', 'type', 'amount', 'shares', 'accountType', 'currency', 'taxes', 'fees', 'transferTargetAccount']
+
+
+@pytest.fixture(name='validation_results')
+def provide_validation_results() -> dict[str, ValidationResult]:
+    """Portfolio with a linked transfer, an unlinked (None) transfer, an empty-string transfer and a plain holding."""
+    accounts = pd.DataFrame([
+        ['Depot 1', AccountType.SECURITIES.value, None, False, 'EUR'],
+        ['Depot 2', AccountType.SECURITIES.value, None, False, 'EUR'],
+    ], columns=['name', 'type', 'referenceAccount', 'isRetired', 'currency'], index=['depot1', 'depot2'])
+    accounts.index.name = 'accountId'
+
+    securities = pd.DataFrame([
+        ['Security Linked', 'AAA', 'ISIN-A', None, False, 'EUR'],
+        ['Security Unlinked', 'BBB', 'ISIN-B', None, False, 'EUR'],
+        ['Security Empty', 'CCC', 'ISIN-C', None, False, 'EUR'],
+        ['Security Plain', 'DDD', 'ISIN-D', None, False, 'EUR'],
+    ], columns=['name', 'wkn', 'isin', 'note', 'isRetired', 'currency'],
+       index=['sec-linked', 'sec-unlinked', 'sec-empty', 'sec-plain'])
+    securities.index.name = 'securityId'
+
+    prices = pd.DataFrame([
+        [datetime(2023, 1, 1), sid, 100.0] for sid in ['sec-linked', 'sec-unlinked', 'sec-empty', 'sec-plain']
+    ], columns=['date', 'securityId', 'price']).set_index(['date', 'securityId'])
+
+    transactions = pd.DataFrame([
+        [datetime(2020, 1, 15), 'depot1', 'sec-linked', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2021, 1, 15), 'depot1', 'sec-linked', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, 'depot2'],
+        [datetime(2021, 1, 15), 'depot2', 'sec-linked', TransactionType.TRANSFER_IN.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2020, 1, 15), 'depot1', 'sec-unlinked', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2021, 1, 15), 'depot1', 'sec-unlinked', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2020, 1, 15), 'depot1', 'sec-empty', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+        [datetime(2021, 1, 15), 'depot1', 'sec-empty', TransactionType.TRANSFER_OUT.value, 0.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, ''],
+        [datetime(2020, 1, 15), 'depot1', 'sec-plain', TransactionType.BUY.value, -1000.0, 10.0, AccountType.SECURITIES.value, 'EUR', 0.0, 0.0, None],
+    ], columns=_COLUMNS).set_index(['date', 'accountId', 'securityId'])
+
+    portfolio = Portfolio(accounts=accounts, transactions=transactions, securities=securities, prices=prices)
+    snapshot = PortfolioSnapshot(portfolio, datetime(2023, 1, 1))
+    return validate_securities(portfolio, snapshot, {})
+
+
+def test_unlinked_transfer_is_flagged(validation_results: dict[str, ValidationResult]) -> None:
+    assert len(validation_results['sec-unlinked'].violations) == 1
+    assert 'no linked destination account' in validation_results['sec-unlinked'].messages
+    assert '10.00 from "Depot 1"' in validation_results['sec-unlinked'].messages
+
+
+def test_empty_string_target_is_flagged(validation_results: dict[str, ValidationResult]) -> None:
+    """An empty (non-null) destination account must be treated the same as a missing link."""
+    assert len(validation_results['sec-empty'].violations) == 1
+    assert 'no linked destination account' in validation_results['sec-empty'].messages
+
+
+def test_unlinked_transfer_is_warning_not_error(validation_results: dict[str, ValidationResult]) -> None:
+    assert not validation_results['sec-unlinked'].has_errors
+    assert '⚠️' in validation_results['sec-unlinked'].messages
+
+
+def test_properly_linked_transfer_is_not_flagged(validation_results: dict[str, ValidationResult]) -> None:
+    assert not validation_results['sec-linked'].violations
+
+
+def test_security_without_transfer_is_not_flagged(validation_results: dict[str, ValidationResult]) -> None:
+    assert not validation_results['sec-plain'].violations


### PR DESCRIPTION
## Summary                                                                                                                
                                           
This is a follow-up PR for https://github.com/ma4nn/pp-terminal/pull/59 to separate the multiple changes in that PR into single ones.
                                                           
  It teaches the FIFO cost-basis engine to respect Portfolio Performance **depot transfers**. On a linked `TRANSFER_OUT`/`TRANSFER_IN` pair, the cost-basis lot is relocated from the source to the destination account, preserving original acquisition date, price, and (prorated) fees — so per-account cost basis, `view securities`, and `simulate share-sell` stay correct after transfers.                                                                                 
                                                                                                                            
  - **Engine** (`cost_basis.py`): relocate lots on linked transfers; split + prorate on partial transfers; destination      
  consumes by original acquisition date; FIFO scoped per `(account, security)`.                                             
  - **Link** (`pp_portfolio_builder.py`, `schemas.py`): destination read from PP's `xact_cross_entry`, surfaced as          
  `transferTargetAccount`.                                                                                                  
  - **Vorabpauschale** (`tax.py`): deemed income attributed per lot, fixing a double-count / crash when a transfer creates  
  two lots sharing one `(date, account, security)` key.                                                                     
  - **share-sell** (`simulate_share_sell.py`): `--account-id` scopes by net share balance; cross-account FIFO resolves      
  transferred lots.                                                                                                         
  - **Validation** (`rules.py`): built-in `unlinked-depot-transfer` rule (a `warning`, on by default) flags transfers with  
  no cross-entry link.                                                                                                      
                                                                                                                            
  ## Behavior changes                                                                                                       
                                                                                                                            
  - `share-sell --shares` without `--account-id` now picks the globally-oldest lot across accounts (was per-account).       
  - `share-sell --account-id <source>` no longer offers an **unlinked** transfer's net-0 source lots; cost-basis totals stay
  correct, and the data is surfaced by the default-on validation rule plus an engine `WARNING` during computation.          
                                                                                                                            
  ## Known limitations                                                                                                      
                                                                                                                            
  - **Same-day ordering** is ambiguous (PP dates are day-granular) — resolved deterministically but a same-day cross-account transfer may not match PP's attribution; shares are always conserved. Same cause can strand shares in a chained same-day `A → B → C` (logs a warning).                                                                                                 
  - **Unlinked transfers**: cost basis kept in source (flagged by the default-on `unlinked-depot-transfer` warning and an engine log warning), not sellable via `--account-id`.                                                                     
  - A stale pre-feature `.cache.db` can `OperationalError` on the new join (low probability; delete cache or use `--no-cache`).                                                                                                            
                                                                                                                            
  ## Testing                                                                                                                
                                                                                                                            
  New tests cover full/partial/chained/round-trip/over transfers, cross-account FIFO by acquisition date, per-lot           
  Vorabpauschale, share-sell scoping, per-security FIFO isolation, and the validation rule. Full suite passes; pylint 10/10;
  bandit clean.