### PR TITLE
Add MCP cash flow query

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ pp-terminal mcp
 
 ### Inspect Portfolio
 
-| Command           | Description                                                                            |
-|-------------------|----------------------------------------------------------------------------------------|
-| `view accounts`   | Get detailed information about the balances per each deposit and/or securities account |
-| `view securities` | Get detailed information about the securities                                          |
-| `view taxonomies` | Get detailed information about the taxonomies                                          |
+| Command            | Description                                                                            |
+|--------------------|----------------------------------------------------------------------------------------|
+| `view accounts`    | Get detailed information about the balances per each deposit and/or securities account |
+| `view cash-flows`  | Get the cumulative deposits, withdrawals and net contributions per currency            |
+| `view securities`  | Get detailed information about the securities                                          |
+| `view taxonomies`  | Get detailed information about the taxonomies                                          |
 
 The displayed columns are configurable via `[commands.view.accounts]` / `[commands.view.securities]` in the
 [configuration file](#configuration-file) — run `pp-terminal init` for the field reference, and call a command with

--- a/pp_terminal/commands/simulate_interest.py
+++ b/pp_terminal/commands/simulate_interest.py
@@ -25,11 +25,10 @@ import numpy as np
 import pandas as pd
 import typer
 from pandera.typing import DataFrame
-from rich.console import Console
 
 from pp_terminal.data.filters import filter_later_than, filter_by_type
 from pp_terminal.utils.helper import get_last_year, footer
-from pp_terminal.output.strategy import OutputStrategy
+from pp_terminal.output.strategy import Console, OutputStrategy
 from pp_terminal.domain.portfolio import Portfolio
 from pp_terminal.domain.portfolio_snapshot import PortfolioSnapshot
 from pp_terminal.domain.schemas import Percent, TransactionType, Money, InterestResultSchema
@@ -53,11 +52,11 @@ def calculate_interest(snapshot_begin: PortfolioSnapshot, snapshot_end: Portfoli
     df['balance'] = df.groupby(['accountId', 'currency'])['amount'].cumsum()
     df['weighted_balance'] = df['balance'] * df['days_diff']
     df['interest_rate'] = np.power(1 + interest_rate / 100 / _DAYS_PER_YEAR, df['days_diff']) - 1
-    df['interest'] = df['balance'] * df['interest_rate']
+    df['simulatedInterest'] = df['balance'] * df['interest_rate']
 
     df = df.pipe(filter_later_than, target_date=snapshot_begin.date)
-    df = df.groupby(['accountId', 'currency']).agg({'interest': 'sum', 'weighted_balance': 'sum', 'days_diff': 'sum'})
-    df['mean_balance'] = (df['weighted_balance'] / df['days_diff']).fillna(0)
+    df = df.groupby(['accountId', 'currency']).agg({'simulatedInterest': 'sum', 'weighted_balance': 'sum', 'days_diff': 'sum'})
+    df['meanBalance'] = (df['weighted_balance'] / df['days_diff']).fillna(0)
 
     df = df.reset_index(level='currency')
 
@@ -67,7 +66,7 @@ def calculate_interest(snapshot_begin: PortfolioSnapshot, snapshot_end: Portfoli
     interest_transactions['amount'] = interest_transactions['amount'] + interest_transactions['taxes']
 
     actual_interest_df = interest_transactions.groupby(['accountId', 'currency'])['amount'].sum().fillna(0).reset_index(level='currency')
-    actual_interest_df = actual_interest_df.rename(columns={'amount': 'actual_interest'})
+    actual_interest_df = actual_interest_df.rename(columns={'amount': 'actualInterest'})
 
     # Merge actual interest into main dataframe
     df = df.merge(actual_interest_df, left_index=True, right_index=True, how='left', suffixes=('', '_drop'))
@@ -77,19 +76,19 @@ def calculate_interest(snapshot_begin: PortfolioSnapshot, snapshot_end: Portfoli
 
     # Merge with account names - deposit_accounts also has currency, so we'll get currency_x and currency_y
     interest_per_account = (pd.merge(snapshot_end.portfolio.deposit_accounts, df, left_index=True, right_index=True, how="right", validate='one_to_one', suffixes=('_account', ''))
-                .sort_values(by='interest'))
+                .sort_values(by='simulatedInterest'))
 
     # Keep the currency from df (interest calculations), drop the one from accounts
     if 'currency_account' in interest_per_account.columns:
         interest_per_account = interest_per_account.drop(columns=['currency_account'])
 
-    result = interest_per_account[interest_per_account['interest'] > 0][['name', 'currency', 'mean_balance', 'interest', 'actual_interest']]
+    result = interest_per_account[interest_per_account['simulatedInterest'] > 0][['name', 'currency', 'meanBalance', 'simulatedInterest', 'actualInterest']]
     return InterestResultSchema.validate(result)
 
 
 def _format_value_wrapper(value: Any, index: str, row: pd.Series) -> str:
-    if index == 'Actual Interest' and isinstance(value, Money):
-        color = 'red' if value < row['Simulated Interest'] else 'green'
+    if index == 'actualInterest' and isinstance(value, Money):
+        color = 'red' if value < row['simulatedInterest'] else 'green'
         return colorize(format_value(value, index, row), color)
 
     return format_value(value, index, row)
@@ -112,8 +111,7 @@ def simulate_interest_rate(
     snapshot_end = PortfolioSnapshot(portfolio, datetime(year.year, 12, 31))
 
     df = calculate_interest(snapshot_begin, snapshot_end, interest_rate)
-    df = df.rename(columns={'mean_balance': '⌀ Balance', 'interest': 'Simulated Interest', 'actual_interest': 'Actual Interest'})
-    df.insert(3, 'Interest Rate', f"{interest_rate}%")
+    df.insert(3, 'interestRate', f"{interest_rate}%")
 
     console.print(*output.result_table(
         df, TableOptions(title='Simulated Interest on Accounts', caption=f"for {year.strftime("%Y")}, excl. taxes", show_index=False, show_total=False, value_formatter=_format_value_wrapper)

--- a/pp_terminal/commands/view_cash_flows.py
+++ b/pp_terminal/commands/view_cash_flows.py
@@ -1,0 +1,116 @@
+"""
+    Copyright (C) 2025-26 Dipl.-Ing. Christoph Massmann <chris@dev-investor.de>
+
+    This file is part of pp-terminal.
+
+    pp-terminal is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    pp-terminal is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with pp-terminal. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from datetime import datetime
+from typing import Annotated, cast
+
+import pandas as pd
+import typer
+from pandera.typing import DataFrame
+
+from pp_terminal.data.filters import filter_by_account, filter_by_type
+from pp_terminal.domain.portfolio import Portfolio
+from pp_terminal.domain.portfolio_snapshot import PortfolioSnapshot
+from pp_terminal.domain.schemas import CashFlowResultSchema, TransactionType
+from pp_terminal.exceptions import InputError
+from pp_terminal.output.strategy import Console, OutputStrategy
+from pp_terminal.output.table_decorator import TableOptions
+from pp_terminal.utils.helper import footer
+
+app = typer.Typer()
+console = Console()
+
+
+def resolve_deposit_account(portfolio: Portfolio, account: str) -> str:
+    accounts = portfolio.deposit_accounts
+    if account in accounts.index:
+        return account
+
+    name_matches = accounts.index[accounts['name'] == account]
+    if len(name_matches) == 1:
+        return str(name_matches[0])
+    if len(name_matches) > 1:
+        raise InputError(f"Name '{account}' matches multiple deposit accounts: {list(name_matches)}")
+
+    raise InputError(f"Deposit account '{account}' not found by ID or name. Available: {list(accounts['name'])}")
+
+
+def prepare_cash_flows_df(
+        portfolio: Portfolio,
+        by: datetime,
+        account_id: str | None = None,
+        include_transfers: bool = False,
+) -> DataFrame[CashFlowResultSchema]:
+    """Aggregates external cash flows per currency, from the beginning of the file through `by`."""
+    transactions = PortfolioSnapshot(portfolio, by).deposit_account_transactions
+    if account_id is not None:
+        transactions = transactions.pipe(filter_by_account, account_id=account_id)
+
+    deposit_types = [TransactionType.DEPOSIT]
+    withdrawal_types = [TransactionType.REMOVAL]
+    if include_transfers:
+        deposit_types.append(TransactionType.TRANSFER_IN)
+        withdrawal_types.append(TransactionType.TRANSFER_OUT)
+
+    deposits = transactions.pipe(filter_by_type, transaction_types=deposit_types)
+    withdrawals = transactions.pipe(filter_by_type, transaction_types=withdrawal_types)
+
+    deposits_by_currency = deposits.groupby('currency')['amount'].sum()
+    # withdrawals are stored as negative amounts, report them as a positive figure
+    withdrawals_by_currency = -withdrawals.groupby('currency')['amount'].sum()
+    currencies = deposits_by_currency.index.union(withdrawals_by_currency.index)
+
+    result = pd.DataFrame(index=currencies)
+    result['totalDeposits'] = deposits_by_currency
+    result['totalWithdrawals'] = withdrawals_by_currency
+    result = result.fillna(0.0)
+    result['netContributions'] = result['totalDeposits'] - result['totalWithdrawals']
+    result['transactionCount'] = (pd.concat([deposits, withdrawals])
+                                  .groupby('currency').size()
+                                  .reindex(currencies, fill_value=0))
+
+    return CashFlowResultSchema.validate(result.reset_index(names='currency'))
+
+
+@app.command(name="cash-flows")
+def print_cash_flows(
+        ctx: typer.Context,
+        account: Annotated[str | None, typer.Option(help="Restrict to one deposit account, given as its ID or name")] = None,
+        by: datetime = datetime.now(),
+        include_transfers: Annotated[bool, typer.Option(help="Include transfers between your own deposit accounts")] = False,
+) -> None:
+    """
+    Show cumulative deposits, withdrawals and net contributions per currency.
+    """
+
+    portfolio = cast(Portfolio, ctx.obj.portfolio)
+    output = cast(OutputStrategy, ctx.obj.output)
+
+    account_id = resolve_deposit_account(portfolio, account) if account else None
+    df = prepare_cash_flows_df(portfolio, by, account_id, include_transfers)
+
+    console.print(*output.result_table(
+        df, TableOptions(
+            title="Cash Flows",
+            caption=f"per {by.strftime("%Y-%m-%d")}, {'incl.' if include_transfers else 'excl.'} internal transfers",
+            show_index=False,
+            show_total=False  # summing across currencies would be meaningless
+        )
+    ))
+    console.print(output.text(footer()), style="dim")

--- a/pp_terminal/domain/schemas.py
+++ b/pp_terminal/domain/schemas.py
@@ -148,14 +148,23 @@ class TaxLotSellSchema(TaxLotSchema):
     netProceeds: Series[Money]
 
 
+class CashFlowResultSchema(_CoercingSchema):
+    """Schema for cumulative external cash flow results, one row per currency."""
+    currency: Series[str]
+    totalDeposits: Series[Money]
+    totalWithdrawals: Series[Money]
+    netContributions: Series[Money]
+    transactionCount: Series[int]
+
+
 class InterestResultSchema(_CoercingSchema):
     """Schema for interest calculation results."""
     accountId: Index[str]
     name: Series[str]
     currency: Series[str]
-    mean_balance: Series[Money]
-    interest: Series[Money]
-    actual_interest: Series[Money] = pa.Field(nullable=True)
+    meanBalance: Series[Money]
+    simulatedInterest: Series[Money]
+    actualInterest: Series[Money] = pa.Field(nullable=True)
 
     @classmethod
     def empty(cls, *_args: Any) -> DataFrame['InterestResultSchema']:

--- a/pp_terminal/mcp_server.py
+++ b/pp_terminal/mcp_server.py
@@ -30,12 +30,13 @@ from mcp.server.fastmcp import FastMCP
 
 from pp_terminal.commands.simulate_share_sell import prepare_share_sell_df, summarize_sell_plan
 from pp_terminal.commands.view_accounts import prepare_accounts_df
+from pp_terminal.commands.view_cash_flows import prepare_cash_flows_df, resolve_deposit_account
 from pp_terminal.commands.view_securities import prepare_securities_df
 from pp_terminal.commands.view_taxonomies import prepare_taxonomies_df
 from pp_terminal.data.filters import clean_for_display
 from pp_terminal.data.tax import load_prepaid_tax_data
 from pp_terminal.domain.portfolio import Portfolio
-from pp_terminal.domain.schemas import AccountType, TransactionType
+from pp_terminal.domain.schemas import AccountType
 from pp_terminal.data.pp_portfolio_builder import CachedPpPortfolioBuilder
 from pp_terminal.exceptions import InputError
 from pp_terminal.output.strategy import JsonOutputStrategy
@@ -108,58 +109,6 @@ def _resolve_security(portfolio: Portfolio, security: str) -> str:
         raise InputError(f"WKN '{security}' matches multiple securities: {list(wkn_matches)}")
 
     raise InputError(f"Security '{security}' not found by ID or ISIN OR WKN")
-
-
-def _resolve_deposit_account(portfolio: Portfolio, account: str) -> str:
-    accounts = portfolio.deposit_accounts
-    if account in accounts.index:
-        return account
-
-    name_matches = accounts.index[accounts['name'] == account]
-    if len(name_matches) == 1:
-        return str(name_matches[0])
-    if len(name_matches) > 1:
-        raise InputError(f"Name '{account}' matches multiple deposit accounts: {list(name_matches)}")
-
-    raise InputError(f"Deposit account '{account}' not found by ID or name. Available: {list(accounts['name'])}")
-
-
-def _calculate_cash_flows(
-    transactions: pd.DataFrame,
-    account_id: str | None = None,
-    include_transfers: bool = False,
-) -> pd.DataFrame:
-    """Aggregate external cash flows by currency."""
-    if account_id is not None:
-        transactions = transactions[
-            transactions.index.get_level_values('accountId') == account_id
-        ]
-
-    deposit_types = [TransactionType.DEPOSIT.value]
-    withdrawal_types = [TransactionType.REMOVAL.value]
-    if include_transfers:
-        deposit_types.append(TransactionType.TRANSFER_IN.value)
-        withdrawal_types.append(TransactionType.TRANSFER_OUT.value)
-
-    deposits = transactions[transactions['type'].isin(deposit_types)]
-    withdrawals = transactions[transactions['type'].isin(withdrawal_types)]
-    deposits_by_currency = deposits.groupby('currency')['amount'].sum()
-    withdrawals_by_currency = -withdrawals.groupby('currency')['amount'].sum()
-    currencies = deposits_by_currency.index.union(withdrawals_by_currency.index)
-
-    result = pd.DataFrame(index=currencies)
-    result['totalDeposits'] = deposits_by_currency
-    result['totalWithdrawals'] = withdrawals_by_currency
-    result = result.fillna(0.0)
-    result['netContributions'] = result['totalDeposits'] - result['totalWithdrawals']
-    flow_types = deposit_types + withdrawal_types
-    result['transactionCount'] = (
-        transactions[transactions['type'].isin(flow_types)]
-        .groupby('currency').size()
-        .reindex(currencies, fill_value=0)
-        .astype(int)
-    )
-    return result.reset_index(names='currency')
 
 
 def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: disable=too-many-locals,too-many-statements
@@ -282,10 +231,9 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         """
         portfolio = _ensure_fresh_portfolio()
         by_date = datetime.fromisoformat(date) if date else datetime.now()
-        resolved_account_id = _resolve_deposit_account(portfolio, account_id) if account_id else None
-        transactions = PortfolioSnapshot(portfolio, by_date).deposit_account_transactions
-        result = _calculate_cash_flows(transactions, resolved_account_id, include_transfers)
-        return _clean_records(result)
+        resolved_account_id = resolve_deposit_account(portfolio, account_id) if account_id else None
+        df = prepare_cash_flows_df(portfolio, by_date, resolved_account_id, include_transfers)
+        return _clean_records(df)
 
     @mcp.tool()
     def simulate_vap(

--- a/pp_terminal/mcp_server.py
+++ b/pp_terminal/mcp_server.py
@@ -110,6 +110,20 @@ def _resolve_security(portfolio: Portfolio, security: str) -> str:
     raise InputError(f"Security '{security}' not found by ID or ISIN OR WKN")
 
 
+def _resolve_deposit_account(portfolio: Portfolio, account: str) -> str:
+    accounts = portfolio.deposit_accounts
+    if account in accounts.index:
+        return account
+
+    name_matches = accounts.index[accounts['name'] == account]
+    if len(name_matches) == 1:
+        return str(name_matches[0])
+    if len(name_matches) > 1:
+        raise InputError(f"Name '{account}' matches multiple deposit accounts: {list(name_matches)}")
+
+    raise InputError(f"Deposit account '{account}' not found by ID or name. Available: {list(accounts['name'])}")
+
+
 def _calculate_cash_flows(
     transactions: pd.DataFrame,
     account_id: str | None = None,
@@ -241,20 +255,36 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
     ) -> list[dict[str, Any]]:
         """Calculate cumulative deposits, withdrawals, and net contributions.
 
+        Each row is one currency showing: currency, totalDeposits, totalWithdrawals,
+        netContributions (totalDeposits - totalWithdrawals), and transactionCount.
         Results are grouped by currency because amounts in different currencies
         must not be added together. Deposits and withdrawals include all
         transactions from the beginning of the file through the requested date.
         Internal transfers are excluded by default.
 
+        totalWithdrawals is reported as a positive number, so netContributions is
+        negative once withdrawals exceed deposits. transactionCount counts deposits
+        and withdrawals together, not deposits alone.
+
+        Only cash movements on deposit accounts are counted. Securities delivered
+        into or out of the portfolio in kind (DELIVERY_INBOUND / DELIVERY_OUTBOUND,
+        e.g. a transfer from another broker) never touch a deposit account and are
+        therefore not part of netContributions.
+
         Args:
             date: Include transactions through this ISO date (defaults to today).
-            account_id: Restrict the result to one deposit account.
-            include_transfers: Include TRANSFER_IN and TRANSFER_OUT transactions.
+            account_id: Restrict the result to one deposit account, given as its
+                accountId or its name. Raises an error if it matches no account.
+            include_transfers: Include TRANSFER_IN and TRANSFER_OUT transactions,
+                i.e. cash moved between two of your own deposit accounts. These
+                net to zero across the whole portfolio, so enable this only
+                together with account_id.
         """
         portfolio = _ensure_fresh_portfolio()
         by_date = datetime.fromisoformat(date) if date else datetime.now()
+        resolved_account_id = _resolve_deposit_account(portfolio, account_id) if account_id else None
         transactions = PortfolioSnapshot(portfolio, by_date).deposit_account_transactions
-        result = _calculate_cash_flows(transactions, account_id, include_transfers)
+        result = _calculate_cash_flows(transactions, resolved_account_id, include_transfers)
         return _clean_records(result)
 
     @mcp.tool()

--- a/pp_terminal/mcp_server.py
+++ b/pp_terminal/mcp_server.py
@@ -35,7 +35,7 @@ from pp_terminal.commands.view_taxonomies import prepare_taxonomies_df
 from pp_terminal.data.filters import clean_for_display
 from pp_terminal.data.tax import load_prepaid_tax_data
 from pp_terminal.domain.portfolio import Portfolio
-from pp_terminal.domain.schemas import AccountType
+from pp_terminal.domain.schemas import AccountType, TransactionType
 from pp_terminal.data.pp_portfolio_builder import CachedPpPortfolioBuilder
 from pp_terminal.exceptions import InputError
 from pp_terminal.output.strategy import JsonOutputStrategy
@@ -55,6 +55,7 @@ Workflow:
 Tool selection guide:
 - "Show my holdings" / "What securities do I have?" → query_securities
 - "Show my accounts" / "What is my cash balance?" → query_accounts
+- "How much have I deposited?" / "What are my net contributions?" → query_cash_flows
 - "What taxonomies exist?" / "Show asset allocation categories" → portfolio://taxonomies resource
 - "What if I sell everything?" / "Total tax on my portfolio?" → simulate_sell_all
 - "I need X EUR after tax" / "Sell to get X net" / "Minimize taxes for X amount" → simulate_sell_target_net
@@ -107,6 +108,44 @@ def _resolve_security(portfolio: Portfolio, security: str) -> str:
         raise InputError(f"WKN '{security}' matches multiple securities: {list(wkn_matches)}")
 
     raise InputError(f"Security '{security}' not found by ID or ISIN OR WKN")
+
+
+def _calculate_cash_flows(
+    transactions: pd.DataFrame,
+    account_id: str | None = None,
+    include_transfers: bool = False,
+) -> pd.DataFrame:
+    """Aggregate external cash flows by currency."""
+    if account_id is not None:
+        transactions = transactions[
+            transactions.index.get_level_values('accountId') == account_id
+        ]
+
+    deposit_types = [TransactionType.DEPOSIT.value]
+    withdrawal_types = [TransactionType.REMOVAL.value]
+    if include_transfers:
+        deposit_types.append(TransactionType.TRANSFER_IN.value)
+        withdrawal_types.append(TransactionType.TRANSFER_OUT.value)
+
+    deposits = transactions[transactions['type'].isin(deposit_types)]
+    withdrawals = transactions[transactions['type'].isin(withdrawal_types)]
+    deposits_by_currency = deposits.groupby('currency')['amount'].sum()
+    withdrawals_by_currency = -withdrawals.groupby('currency')['amount'].sum()
+    currencies = deposits_by_currency.index.union(withdrawals_by_currency.index)
+
+    result = pd.DataFrame(index=currencies)
+    result['totalDeposits'] = deposits_by_currency
+    result['totalWithdrawals'] = withdrawals_by_currency
+    result = result.fillna(0.0)
+    result['netContributions'] = result['totalDeposits'] - result['totalWithdrawals']
+    flow_types = deposit_types + withdrawal_types
+    result['transactionCount'] = (
+        transactions[transactions['type'].isin(flow_types)]
+        .groupby('currency').size()
+        .reindex(currencies, fill_value=0)
+        .astype(int)
+    )
+    return result.reset_index(names='currency')
 
 
 def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: disable=too-many-locals,too-many-statements
@@ -193,6 +232,30 @@ def create_mcp_server(file_path: Path, config: Config) -> FastMCP:  # pylint: di
         parsed_type = AccountType[account_type] if account_type else None
         df = prepare_accounts_df(portfolio, config, output, by_date, parsed_type)
         return _clean_records(df.reset_index())
+
+    @mcp.tool()
+    def query_cash_flows(
+        date: str | None = None,
+        account_id: str | None = None,
+        include_transfers: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Calculate cumulative deposits, withdrawals, and net contributions.
+
+        Results are grouped by currency because amounts in different currencies
+        must not be added together. Deposits and withdrawals include all
+        transactions from the beginning of the file through the requested date.
+        Internal transfers are excluded by default.
+
+        Args:
+            date: Include transactions through this ISO date (defaults to today).
+            account_id: Restrict the result to one deposit account.
+            include_transfers: Include TRANSFER_IN and TRANSFER_OUT transactions.
+        """
+        portfolio = _ensure_fresh_portfolio()
+        by_date = datetime.fromisoformat(date) if date else datetime.now()
+        transactions = PortfolioSnapshot(portfolio, by_date).deposit_account_transactions
+        result = _calculate_cash_flows(transactions, account_id, include_transfers)
+        return _clean_records(result)
 
     @mcp.tool()
     def simulate_vap(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "mcp (>=1.28.1,<2.0.0)",
 ]
 scripts = { pp-terminal = "pp_terminal.main:app" }
-entry-points = { "pp_terminal.commands" = { "view.accounts" = "pp_terminal.commands.view_accounts:app", "view.securities" = "pp_terminal.commands.view_securities:app", "view.taxonomies" = "pp_terminal.commands.view_taxonomies:app", "simulate.vorabpauschale" = "pp_terminal.commands.simulate_vap:app", "simulate.interest" = "pp_terminal.commands.simulate_interest:app", "simulate.share-sell" = "pp_terminal.commands.simulate_share_sell:app", "simulate.pmt" = "pp_terminal.commands.simulate_pmt:app", "validate" = "pp_terminal.commands.validate:app", "export" = "pp_terminal.commands.export:app", "init" = "pp_terminal.commands.init:app" } }
+entry-points = { "pp_terminal.commands" = { "view.accounts" = "pp_terminal.commands.view_accounts:app", "view.cash-flows" = "pp_terminal.commands.view_cash_flows:app", "view.securities" = "pp_terminal.commands.view_securities:app", "view.taxonomies" = "pp_terminal.commands.view_taxonomies:app", "simulate.vorabpauschale" = "pp_terminal.commands.simulate_vap:app", "simulate.interest" = "pp_terminal.commands.simulate_interest:app", "simulate.share-sell" = "pp_terminal.commands.simulate_share_sell:app", "simulate.pmt" = "pp_terminal.commands.simulate_pmt:app", "validate" = "pp_terminal.commands.validate:app", "export" = "pp_terminal.commands.export:app", "init" = "pp_terminal.commands.init:app" } }
 dynamic = ["version"]
 
 

--- a/tests/commands/test_integration.py
+++ b/tests/commands/test_integration.py
@@ -554,3 +554,28 @@ def test_view_accounts_json_output(request: TopRequest) -> None:
     expected_rows = json.loads(Path(golden_file).read_text(encoding='utf-8'))
 
     assert actual_rows == expected_rows
+
+
+def test_simulate_interest_json_output_is_parseable(request: TopRequest) -> None:
+    """A console without soft wrapping folds the payload at the terminal width, injecting newlines into the JSON."""
+    runner = CliRunner()
+    fixtures_dir = request.path.parent.parent / 'fixtures'
+
+    result = runner.invoke(app, [
+        '--file', str(fixtures_dir / 'kommer.ids.xml'),
+        '--output', 'json',
+        '--no-cache',
+        'simulate', 'interest',
+        '--interest-rate', '2',
+        '--year', '2024'
+    ])
+
+    assert result.exit_code == 0, f"Command failed with: {result.output}"
+    assert json.loads(result.stdout) == [{
+        'name': 'Wertpapierkonto',
+        'currency': 'EUR',
+        'meanBalance': 572.8546212121,
+        'interestRate': '2.0%',
+        'simulatedInterest': 4.2063464864,
+        'actualInterest': None,
+    }]

--- a/tests/commands/test_simulate_interest.py
+++ b/tests/commands/test_simulate_interest.py
@@ -26,11 +26,12 @@ from _pytest.fixtures import TopRequest
 from pandas.testing import assert_frame_equal
 from pandera.typing import DataFrame
 
-from pp_terminal.commands.simulate_interest import calculate_interest
+from pp_terminal.commands.simulate_interest import calculate_interest, _format_value_wrapper
 from pp_terminal.domain.portfolio import Portfolio
 from pp_terminal.domain.portfolio_snapshot import PortfolioSnapshot
 from pp_terminal.data.pp_portfolio_builder import PpPortfolioBuilder
 from pp_terminal.domain.schemas import InterestResultSchema
+from pp_terminal.utils.helper import format_money
 
 
 def test_empty_portfolio() -> None:
@@ -61,7 +62,7 @@ def test_kommer(request: TopRequest) -> None:
     # Create expected DataFrame with type annotation and runtime validation
     expected_df: DataFrame[InterestResultSchema] = pd.DataFrame([
         ['Wertpapierkonto', 'EUR', 339.54724, 13.46723, np.nan],
-    ], columns=['name', 'currency', 'mean_balance', 'interest', 'actual_interest'])
+    ], columns=['name', 'currency', 'meanBalance', 'simulatedInterest', 'actualInterest'])
     expected_df.index = pd.Index(['e068fb14-2554-427e-b2d0-30dcc6e15717'], name='accountId')
     expected_df = InterestResultSchema.validate(expected_df)
 
@@ -85,3 +86,20 @@ def test_empty_file(request: TopRequest) -> None:
     # - Empty XML: Index([], dtype='object'), columns with dtype='object'
     # - Schema: Index([], dtype='str'), columns with StringDtype
     assert_frame_equal(expected_df, result, check_dtype=False, check_index_type=False)
+
+
+def _row(actual_interest: float) -> pd.Series:
+    return pd.Series({
+        'name': 'Testkonto', 'currency': 'EUR', 'meanBalance': 1000.0,
+        'simulatedInterest': 20.0, 'actualInterest': actual_interest,
+    })
+
+
+def test_actual_interest_is_colored_against_the_simulated_one() -> None:
+    """The comparison keys off the column names, so a rename must not silently drop the coloring."""
+    assert _format_value_wrapper(5.0, 'actualInterest', _row(5.0)).startswith('[red]')
+    assert _format_value_wrapper(25.0, 'actualInterest', _row(25.0)).startswith('[green]')
+
+
+def test_other_columns_are_not_colored() -> None:
+    assert _format_value_wrapper(1000.0, 'meanBalance', _row(5.0)) == format_money(1000.0, 'EUR')

--- a/tests/commands/test_view_cash_flows.py
+++ b/tests/commands/test_view_cash_flows.py
@@ -1,0 +1,180 @@
+"""
+    Copyright (C) 2025-26 Dipl.-Ing. Christoph Massmann <chris@dev-investor.de>
+
+    This file is part of pp-terminal.
+
+    pp-terminal is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+"""
+# pylint: disable=duplicate-code
+
+import json
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+import pytest
+from _pytest.fixtures import TopRequest
+from typer.testing import CliRunner
+
+from pp_terminal.commands.view_cash_flows import prepare_cash_flows_df, resolve_deposit_account
+from pp_terminal.data.pp_portfolio_builder import PpPortfolioBuilder
+from pp_terminal.domain.portfolio import Portfolio
+from pp_terminal.domain.schemas import AccountType, TransactionType
+from pp_terminal.exceptions import InputError
+from pp_terminal.main import app
+
+_LATER_THAN_ANY_TRANSACTION = datetime(2030, 1, 1)
+
+
+def _portfolio(account_names: list[str], transactions: list[list[Any]] | None = None) -> Portfolio:
+    accounts = pd.DataFrame(
+        [[name, AccountType.DEPOSIT.value, None, False, 'EUR'] for name in account_names]
+        + [['Testdepot', AccountType.SECURITIES.value, None, False, 'EUR']],
+        columns=['name', 'type', 'referenceAccount', 'isRetired', 'currency'],
+        index=[f'account-{index}' for index in range(len(account_names))] + ['securities-1'],
+    )
+    accounts.index.name = 'accountId'
+
+    transactions_df = pd.DataFrame(
+        transactions or [],
+        columns=['date', 'accountId', 'securityId', 'type', 'amount', 'shares', 'accountType', 'currency', 'taxes', 'fees'],
+    ).set_index(['date', 'accountId', 'securityId'])
+
+    return Portfolio(accounts=accounts, transactions=transactions_df)
+
+
+def _deposit(date: datetime, account_id: str, transaction_type: TransactionType, amount: float, currency: str) -> list[Any]:
+    return [date, account_id, None, transaction_type.value, amount, 0.0, AccountType.DEPOSIT.value, currency, 0.0, 0.0]
+
+
+def _sample_portfolio() -> Portfolio:
+    return _portfolio(['Girokonto', 'Zweitkonto'], [
+        _deposit(datetime(2024, 1, 1), 'account-0', TransactionType.DEPOSIT, 1000.0, 'EUR'),
+        _deposit(datetime(2024, 2, 1), 'account-0', TransactionType.REMOVAL, -250.0, 'EUR'),
+        _deposit(datetime(2024, 3, 1), 'account-0', TransactionType.TRANSFER_IN, 500.0, 'EUR'),
+        _deposit(datetime(2024, 4, 1), 'account-1', TransactionType.DEPOSIT, 300.0, 'USD'),
+        _deposit(datetime(2024, 5, 1), 'account-1', TransactionType.REMOVAL, -50.0, 'USD'),
+    ])
+
+
+def test_excludes_transfers_and_separates_currencies() -> None:
+    result = prepare_cash_flows_df(_sample_portfolio(), _LATER_THAN_ANY_TRANSACTION)
+
+    assert result.to_dict('records') == [
+        {'currency': 'EUR', 'totalDeposits': 1000.0, 'totalWithdrawals': 250.0, 'netContributions': 750.0, 'transactionCount': 2},
+        {'currency': 'USD', 'totalDeposits': 300.0, 'totalWithdrawals': 50.0, 'netContributions': 250.0, 'transactionCount': 2},
+    ]
+
+
+def test_can_include_transfers_and_filter_account() -> None:
+    result = prepare_cash_flows_df(_sample_portfolio(), _LATER_THAN_ANY_TRANSACTION, 'account-0', include_transfers=True)
+
+    assert result.to_dict('records') == [
+        {'currency': 'EUR', 'totalDeposits': 1500.0, 'totalWithdrawals': 250.0, 'netContributions': 1250.0, 'transactionCount': 3},
+    ]
+
+
+def test_counts_only_transactions_up_to_the_given_date() -> None:
+    result = prepare_cash_flows_df(_sample_portfolio(), datetime(2024, 1, 31))
+
+    assert result.to_dict('records') == [
+        {'currency': 'EUR', 'totalDeposits': 1000.0, 'totalWithdrawals': 0.0, 'netContributions': 1000.0, 'transactionCount': 1},
+    ]
+
+
+def test_net_contributions_turn_negative_when_withdrawals_exceed_deposits() -> None:
+    portfolio = _portfolio(['Girokonto'], [
+        _deposit(datetime(2024, 1, 1), 'account-0', TransactionType.DEPOSIT, 100.0, 'EUR'),
+        _deposit(datetime(2024, 2, 1), 'account-0', TransactionType.REMOVAL, -400.0, 'EUR'),
+    ])
+
+    result = prepare_cash_flows_df(portfolio, _LATER_THAN_ANY_TRANSACTION)
+
+    assert result.to_dict('records') == [
+        {'currency': 'EUR', 'totalDeposits': 100.0, 'totalWithdrawals': 400.0, 'netContributions': -300.0, 'transactionCount': 2},
+    ]
+
+
+def test_ignores_transaction_types_that_are_not_external_cash_flows() -> None:
+    portfolio = _portfolio(['Girokonto'], [
+        _deposit(datetime(2024, 1, 1), 'account-0', TransactionType.DEPOSIT, 1000.0, 'EUR'),
+        _deposit(datetime(2024, 2, 1), 'account-0', TransactionType.DIVIDENDS, 50.0, 'EUR'),
+        _deposit(datetime(2024, 3, 1), 'account-0', TransactionType.INTEREST, 10.0, 'EUR'),
+        _deposit(datetime(2024, 4, 1), 'account-0', TransactionType.FEES, -5.0, 'EUR'),
+        _deposit(datetime(2024, 5, 1), 'account-0', TransactionType.BUY, -800.0, 'EUR'),
+    ])
+
+    result = prepare_cash_flows_df(portfolio, _LATER_THAN_ANY_TRANSACTION)
+
+    assert result.to_dict('records') == [
+        {'currency': 'EUR', 'totalDeposits': 1000.0, 'totalWithdrawals': 0.0, 'netContributions': 1000.0, 'transactionCount': 1},
+    ]
+
+
+def test_portfolio_without_cash_flows_yields_empty_result() -> None:
+    result = prepare_cash_flows_df(_portfolio(['Girokonto']), _LATER_THAN_ANY_TRANSACTION)
+
+    assert len(result) == 0
+    assert list(result.columns) == ['currency', 'totalDeposits', 'totalWithdrawals', 'netContributions', 'transactionCount']
+
+
+def test_matches_the_deposits_in_the_sample_file(request: TopRequest) -> None:
+    portfolio = PpPortfolioBuilder().construct(request.path.parent.parent / 'fixtures' / 'kommer.ids.xml')
+
+    result = prepare_cash_flows_df(portfolio, _LATER_THAN_ANY_TRANSACTION)
+
+    assert result.to_dict('records') == [
+        {'currency': 'EUR', 'totalDeposits': 11500.0, 'totalWithdrawals': 0.0, 'netContributions': 11500.0, 'transactionCount': 3},
+        {'currency': 'GBP', 'totalDeposits': 2000.0, 'totalWithdrawals': 0.0, 'netContributions': 2000.0, 'transactionCount': 1},
+        {'currency': 'USD', 'totalDeposits': 3000.0, 'totalWithdrawals': 0.0, 'netContributions': 3000.0, 'transactionCount': 1},
+    ]
+
+
+def test_resolve_deposit_account_accepts_id_and_name() -> None:
+    portfolio = _portfolio(['Girokonto', 'Verrechnungskonto'])
+
+    assert resolve_deposit_account(portfolio, 'account-1') == 'account-1'
+    assert resolve_deposit_account(portfolio, 'Girokonto') == 'account-0'
+
+
+def test_resolve_deposit_account_rejects_unknown_account() -> None:
+    with pytest.raises(InputError, match="'nope' not found"):
+        resolve_deposit_account(_portfolio(['Girokonto']), 'nope')
+
+
+def test_resolve_deposit_account_rejects_securities_account() -> None:
+    with pytest.raises(InputError, match="'securities-1' not found"):
+        resolve_deposit_account(_portfolio(['Girokonto']), 'securities-1')
+
+
+def test_resolve_deposit_account_rejects_ambiguous_name() -> None:
+    with pytest.raises(InputError, match='matches multiple deposit accounts'):
+        resolve_deposit_account(_portfolio(['Girokonto', 'Girokonto']), 'Girokonto')
+
+
+def test_cli_reports_cash_flows_for_one_account(request: TopRequest) -> None:
+    xml_file = request.path.parent.parent / 'fixtures' / 'kommer.ids.xml'
+
+    result = CliRunner().invoke(app, [
+        '--file', str(xml_file), '--output', 'json', '--no-cache',
+        'view', 'cash-flows', '--account', 'Tagesgeld',
+    ])
+
+    assert result.exit_code == 0, f"Command failed with: {result.output}"
+    assert json.loads(result.output) == [
+        {'currency': 'EUR', 'totalDeposits': 500.0, 'totalWithdrawals': 0.0, 'netContributions': 500.0, 'transactionCount': 1},
+    ]
+
+
+def test_cli_rejects_an_unknown_account(request: TopRequest) -> None:
+    xml_file = request.path.parent.parent / 'fixtures' / 'kommer.ids.xml'
+
+    result = CliRunner().invoke(app, [
+        '--file', str(xml_file), '--output', 'json', '--no-cache',
+        'view', 'cash-flows', '--account', 'Nope',
+    ])
+
+    assert result.exit_code != 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,95 +9,65 @@
     (at your option) any later version.
 """
 
-from datetime import datetime
+import asyncio
+from pathlib import Path
+from typing import Any, cast
 
-import pandas as pd
 import pytest
+from _pytest.fixtures import TopRequest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 
-from pp_terminal.domain.portfolio import Portfolio
-from pp_terminal.domain.schemas import AccountType, TransactionType
-from pp_terminal.exceptions import InputError
-from pp_terminal.mcp_server import _calculate_cash_flows, _resolve_deposit_account
-
-
-def _transactions() -> pd.DataFrame:
-    return pd.DataFrame([
-        [datetime(2024, 1, 1), 'account-1', TransactionType.DEPOSIT.value, 1000.0, 'EUR'],
-        [datetime(2024, 2, 1), 'account-1', TransactionType.REMOVAL.value, -250.0, 'EUR'],
-        [datetime(2024, 3, 1), 'account-1', TransactionType.TRANSFER_IN.value, 500.0, 'EUR'],
-        [datetime(2024, 4, 1), 'account-2', TransactionType.DEPOSIT.value, 300.0, 'USD'],
-        [datetime(2024, 5, 1), 'account-2', TransactionType.REMOVAL.value, -50.0, 'USD'],
-    ], columns=['date', 'accountId', 'type', 'amount', 'currency']).set_index(['date', 'accountId'])
+from pp_terminal.mcp_server import create_mcp_server
+from pp_terminal.utils.config import empty_config
 
 
-def test_calculate_cash_flows_excludes_transfers_and_separates_currencies() -> None:
-    result = _calculate_cash_flows(_transactions())
+@pytest.fixture(name='mcp')
+def provide_mcp_server(request: TopRequest) -> FastMCP:
+    xml_file = Path(request.path.parent / 'fixtures' / 'kommer.ids.xml')
+    return create_mcp_server(xml_file, empty_config())
 
-    assert result.to_dict('records') == [
-        {
-            'currency': 'EUR',
-            'totalDeposits': 1000.0,
-            'totalWithdrawals': 250.0,
-            'netContributions': 750.0,
-            'transactionCount': 2,
-        },
-        {
-            'currency': 'USD',
-            'totalDeposits': 300.0,
-            'totalWithdrawals': 50.0,
-            'netContributions': 250.0,
-            'transactionCount': 2,
-        },
+
+def _call(mcp: FastMCP, tool: str, arguments: dict[str, Any] | None = None) -> Any:
+    """Invokes a tool the way a client does and returns its structured result."""
+    _, structured = cast(tuple[Any, dict[str, Any]], asyncio.run(mcp.call_tool(tool, arguments or {})))
+    return structured['result']
+
+
+def test_query_cash_flows_reports_every_currency(mcp: FastMCP) -> None:
+    assert _call(mcp, 'query_cash_flows') == [
+        {'currency': 'EUR', 'totalDeposits': 11500.0, 'totalWithdrawals': 0.0, 'netContributions': 11500.0, 'transactionCount': 3},
+        {'currency': 'GBP', 'totalDeposits': 2000.0, 'totalWithdrawals': 0.0, 'netContributions': 2000.0, 'transactionCount': 1},
+        {'currency': 'USD', 'totalDeposits': 3000.0, 'totalWithdrawals': 0.0, 'netContributions': 3000.0, 'transactionCount': 1},
     ]
 
 
-def test_calculate_cash_flows_can_include_transfers_and_filter_account() -> None:
-    result = _calculate_cash_flows(_transactions(), 'account-1', include_transfers=True)
-
-    assert result.to_dict('records') == [{
-        'currency': 'EUR',
-        'totalDeposits': 1500.0,
-        'totalWithdrawals': 250.0,
-        'netContributions': 1250.0,
-        'transactionCount': 3,
-    }]
+def test_query_cash_flows_honours_the_date_argument(mcp: FastMCP) -> None:
+    """The two 2019 deposits count, the later ones do not."""
+    assert _call(mcp, 'query_cash_flows', {'date': '2020-01-01'}) == [
+        {'currency': 'EUR', 'totalDeposits': 10500.0, 'totalWithdrawals': 0.0, 'netContributions': 10500.0, 'transactionCount': 2},
+    ]
 
 
-def _portfolio(names: list[str]) -> Portfolio:
-    accounts = pd.DataFrame(
-        [[name, AccountType.DEPOSIT.value, None, False, 'EUR'] for name in names]
-        + [['Testdepot', AccountType.SECURITIES.value, None, False, 'EUR']],
-        columns=['name', 'type', 'referenceAccount', 'isRetired', 'currency'],
-        index=[f'account-{i}' for i in range(len(names))] + ['securities-1'],
-    )
-    accounts.index.name = 'accountId'
-
-    return Portfolio(accounts=accounts)
+def test_query_cash_flows_restricts_to_an_account_given_by_name(mcp: FastMCP) -> None:
+    assert _call(mcp, 'query_cash_flows', {'account_id': 'Tagesgeld'}) == [
+        {'currency': 'EUR', 'totalDeposits': 500.0, 'totalWithdrawals': 0.0, 'netContributions': 500.0, 'transactionCount': 1},
+    ]
 
 
-def test_resolve_deposit_account_accepts_id_and_name() -> None:
-    portfolio = _portfolio(['Girokonto', 'Verrechnungskonto'])
-
-    assert _resolve_deposit_account(portfolio, 'account-1') == 'account-1'
-    assert _resolve_deposit_account(portfolio, 'Girokonto') == 'account-0'
-
-
-def test_resolve_deposit_account_rejects_unknown_account() -> None:
-    portfolio = _portfolio(['Girokonto'])
-
-    with pytest.raises(InputError, match="'nope' not found"):
-        _resolve_deposit_account(portfolio, 'nope')
+def test_query_cash_flows_restricts_to_an_account_given_by_id(mcp: FastMCP) -> None:
+    assert _call(mcp, 'query_cash_flows', {'account_id': 'ea9414e0-1787-46c0-92b3-8e2370eb892e'}) == [
+        {'currency': 'EUR', 'totalDeposits': 500.0, 'totalWithdrawals': 0.0, 'netContributions': 500.0, 'transactionCount': 1},
+    ]
 
 
-def test_resolve_deposit_account_rejects_securities_account() -> None:
-    portfolio = _portfolio(['Girokonto'])
-
-    with pytest.raises(InputError, match="'securities-1' not found"):
-        _resolve_deposit_account(portfolio, 'securities-1')
+def test_query_cash_flows_reports_an_unknown_account_instead_of_an_empty_result(mcp: FastMCP) -> None:
+    with pytest.raises(ToolError, match="Deposit account 'Girokonto' not found"):
+        _call(mcp, 'query_cash_flows', {'account_id': 'Girokonto'})
 
 
-def test_resolve_deposit_account_rejects_ambiguous_name() -> None:
-    portfolio = _portfolio(['Girokonto', 'Girokonto'])
+def test_query_cash_flows_is_offered_to_the_model(mcp: FastMCP) -> None:
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
 
-    with pytest.raises(InputError, match='matches multiple deposit accounts'):
-        _resolve_deposit_account(portfolio, 'Girokonto')
+    assert 'query_cash_flows' in tools
+    assert set(tools['query_cash_flows'].inputSchema['properties']) == {'date', 'account_id', 'include_transfers'}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,60 @@
+"""
+    Copyright (C) 2025-26 Dipl.-Ing. Christoph Massmann <chris@dev-investor.de>
+
+    This file is part of pp-terminal.
+
+    pp-terminal is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+"""
+
+from datetime import datetime
+
+import pandas as pd
+
+from pp_terminal.domain.schemas import TransactionType
+from pp_terminal.mcp_server import _calculate_cash_flows
+
+
+def _transactions() -> pd.DataFrame:
+    return pd.DataFrame([
+        [datetime(2024, 1, 1), 'account-1', TransactionType.DEPOSIT.value, 1000.0, 'EUR'],
+        [datetime(2024, 2, 1), 'account-1', TransactionType.REMOVAL.value, -250.0, 'EUR'],
+        [datetime(2024, 3, 1), 'account-1', TransactionType.TRANSFER_IN.value, 500.0, 'EUR'],
+        [datetime(2024, 4, 1), 'account-2', TransactionType.DEPOSIT.value, 300.0, 'USD'],
+        [datetime(2024, 5, 1), 'account-2', TransactionType.REMOVAL.value, -50.0, 'USD'],
+    ], columns=['date', 'accountId', 'type', 'amount', 'currency']).set_index(['date', 'accountId'])
+
+
+def test_calculate_cash_flows_excludes_transfers_and_separates_currencies() -> None:
+    result = _calculate_cash_flows(_transactions())
+
+    assert result.to_dict('records') == [
+        {
+            'currency': 'EUR',
+            'totalDeposits': 1000.0,
+            'totalWithdrawals': 250.0,
+            'netContributions': 750.0,
+            'transactionCount': 2,
+        },
+        {
+            'currency': 'USD',
+            'totalDeposits': 300.0,
+            'totalWithdrawals': 50.0,
+            'netContributions': 250.0,
+            'transactionCount': 2,
+        },
+    ]
+
+
+def test_calculate_cash_flows_can_include_transfers_and_filter_account() -> None:
+    result = _calculate_cash_flows(_transactions(), 'account-1', include_transfers=True)
+
+    assert result.to_dict('records') == [{
+        'currency': 'EUR',
+        'totalDeposits': 1500.0,
+        'totalWithdrawals': 250.0,
+        'netContributions': 1250.0,
+        'transactionCount': 3,
+    }]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -12,9 +12,12 @@
 from datetime import datetime
 
 import pandas as pd
+import pytest
 
-from pp_terminal.domain.schemas import TransactionType
-from pp_terminal.mcp_server import _calculate_cash_flows
+from pp_terminal.domain.portfolio import Portfolio
+from pp_terminal.domain.schemas import AccountType, TransactionType
+from pp_terminal.exceptions import InputError
+from pp_terminal.mcp_server import _calculate_cash_flows, _resolve_deposit_account
 
 
 def _transactions() -> pd.DataFrame:
@@ -58,3 +61,43 @@ def test_calculate_cash_flows_can_include_transfers_and_filter_account() -> None
         'netContributions': 1250.0,
         'transactionCount': 3,
     }]
+
+
+def _portfolio(names: list[str]) -> Portfolio:
+    accounts = pd.DataFrame(
+        [[name, AccountType.DEPOSIT.value, None, False, 'EUR'] for name in names]
+        + [['Testdepot', AccountType.SECURITIES.value, None, False, 'EUR']],
+        columns=['name', 'type', 'referenceAccount', 'isRetired', 'currency'],
+        index=[f'account-{i}' for i in range(len(names))] + ['securities-1'],
+    )
+    accounts.index.name = 'accountId'
+
+    return Portfolio(accounts=accounts)
+
+
+def test_resolve_deposit_account_accepts_id_and_name() -> None:
+    portfolio = _portfolio(['Girokonto', 'Verrechnungskonto'])
+
+    assert _resolve_deposit_account(portfolio, 'account-1') == 'account-1'
+    assert _resolve_deposit_account(portfolio, 'Girokonto') == 'account-0'
+
+
+def test_resolve_deposit_account_rejects_unknown_account() -> None:
+    portfolio = _portfolio(['Girokonto'])
+
+    with pytest.raises(InputError, match="'nope' not found"):
+        _resolve_deposit_account(portfolio, 'nope')
+
+
+def test_resolve_deposit_account_rejects_securities_account() -> None:
+    portfolio = _portfolio(['Girokonto'])
+
+    with pytest.raises(InputError, match="'securities-1' not found"):
+        _resolve_deposit_account(portfolio, 'securities-1')
+
+
+def test_resolve_deposit_account_rejects_ambiguous_name() -> None:
+    portfolio = _portfolio(['Girokonto', 'Girokonto'])
+
+    with pytest.raises(InputError, match='matches multiple deposit accounts'):
+        _resolve_deposit_account(portfolio, 'Girokonto')


### PR DESCRIPTION
## Summary

I wanted to query the amount of total contributions to my portfolio.

- add `query_cash_flows` to the MCP server
- report cumulative deposits, withdrawals, net contributions, and transaction count by currency
- exclude internal transfers by default, with an opt-in `include_transfers` flag
- support date and deposit-account filtering
- add focused aggregation tests

## Verification

- successfully tested with two different portfolio files locally
- `.venv/bin/pytest tests/test_mcp_server.py`
- `.venv/bin/pylint pp_terminal tests`
- `.venv/bin/bandit -c bandit.yaml -r pp_terminal tests`
- `.venv/bin/mypy .`
- `.venv/bin/pp-terminal --no-cache --output json --file tests/fixtures/kommer.ids.xml view accounts`